### PR TITLE
Fix deps uninstall failing on Windows due to locked files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.13
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -148,6 +148,21 @@ Create a symbolic link to your `blender_jps` folder in your Blender addons direc
 5. Go to **Edit → Preferences → Add-ons**
 6. Search for "JuPedSim" and enable the addon
 
+### Pre-commit Hooks
+
+CI runs `ruff check` and `ruff format --check`. To catch these locally before pushing:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Hooks then run on every `git commit`. To check the whole repo on demand:
+
+```bash
+pre-commit run --all-files
+```
+
 ## License
 
 MIT License

--- a/blender_jps/__init__.py
+++ b/blender_jps/__init__.py
@@ -13,8 +13,8 @@ install_utils.ensure_deps_in_path(ADDON_DIR)
 
 bl_info = {
     "name": "BlenderJPS - JuPedSim Importer",
-    "author": "Fabian Plum",
-    "version": (0, 1, 5),
+    "author": "Fabian Plum & Mohcine Chraibi",
+    "version": (0, 1, 6),
     "blender": (4, 0, 0),
     "location": "View3D > Sidebar > JuPedSim",
     "description": "Import JuPedSim trajectory SQLite files with agent animations and geometry",

--- a/blender_jps/preferences.py
+++ b/blender_jps/preferences.py
@@ -64,7 +64,23 @@ class JUPEDSIM_OT_uninstall_dependencies(bpy.types.Operator):
                 if deps_dir in sys.path:
                     sys.path.remove(deps_dir)
 
-                shutil.rmtree(deps_dir)
+                # Unload modules imported from deps so Windows releases file locks
+                deps_prefix = os.path.normcase(deps_dir + os.sep)
+                to_remove = [
+                    name
+                    for name, mod in sys.modules.items()
+                    if getattr(mod, "__file__", None)
+                    and os.path.normcase(mod.__file__).startswith(deps_prefix)
+                ]
+                for name in to_remove:
+                    del sys.modules[name]
+
+                def _on_rm_error(func, path, exc_info):
+                    """Handle read-only or locked files on Windows."""
+                    os.chmod(path, 0o777)
+                    func(path)
+
+                shutil.rmtree(deps_dir, onerror=_on_rm_error)
                 self.report({"INFO"}, "Dependencies uninstalled successfully.")
             except Exception as e:
                 self.report({"ERROR"}, f"Failed to remove deps folder: {e}")

--- a/blender_jps/preferences.py
+++ b/blender_jps/preferences.py
@@ -5,7 +5,9 @@ Handles addon preferences and dependency installation.
 
 import os
 import shutil
+import stat
 import sys
+import time
 
 import bpy
 from bpy.types import AddonPreferences
@@ -13,6 +15,21 @@ from bpy.types import AddonPreferences
 from . import install_utils
 
 ADDON_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+def _handle_rmtree_error(func, path, exc_info):
+    """rmtree onerror handler that clears the read-only bit on Windows.
+
+    Re-raises non-permission errors so the real blocker surfaces instead of a
+    misleading chmod failure.
+    """
+    if sys.platform != "win32" or not isinstance(exc_info[1], PermissionError):
+        raise exc_info[1]
+    try:
+        os.chmod(path, stat.S_IWRITE)
+        func(path)
+    except OSError:
+        raise exc_info[1]
 
 
 class JUPEDSIM_OT_install_dependencies(bpy.types.Operator):
@@ -59,35 +76,54 @@ class JUPEDSIM_OT_uninstall_dependencies(bpy.types.Operator):
     def execute(self, context):
         deps_dir = install_utils.get_deps_dir(ADDON_DIR)
 
-        if os.path.exists(deps_dir):
-            try:
-                if deps_dir in sys.path:
-                    sys.path.remove(deps_dir)
+        if not os.path.exists(deps_dir):
+            self.report({"INFO"}, "No dependencies to uninstall.")
+            return {"FINISHED"}
 
-                # Unload modules imported from deps so Windows releases file locks
-                deps_prefix = os.path.normcase(deps_dir + os.sep)
-                to_remove = [
-                    name
-                    for name, mod in sys.modules.items()
-                    if getattr(mod, "__file__", None)
-                    and os.path.normcase(mod.__file__).startswith(deps_prefix)
-                ]
-                for name in to_remove:
-                    del sys.modules[name]
+        if deps_dir in sys.path:
+            sys.path.remove(deps_dir)
 
-                def _on_rm_error(func, path, exc_info):
-                    """Handle read-only or locked files on Windows."""
-                    os.chmod(path, 0o777)
-                    func(path)
+        # Drop pure-Python modules loaded from deps so their source files can
+        # be removed. Compiled extensions (.pyd/.dll) generally stay mapped
+        # for the lifetime of the Blender process even after sys.modules
+        # eviction, so a Blender restart may still be needed before those
+        # file handles are released.
+        deps_prefix = os.path.normcase(deps_dir + os.sep)
+        to_remove = [
+            name
+            for name, mod in sys.modules.items()
+            if getattr(mod, "__file__", None)
+            and os.path.normcase(mod.__file__).startswith(deps_prefix)
+        ]
+        for name in to_remove:
+            del sys.modules[name]
 
-                shutil.rmtree(deps_dir, onerror=_on_rm_error)
-                self.report({"INFO"}, "Dependencies uninstalled successfully.")
-            except Exception as e:
+        try:
+            shutil.rmtree(deps_dir, onerror=_handle_rmtree_error)
+        except Exception as e:
+            if sys.platform != "win32":
                 self.report({"ERROR"}, f"Failed to remove deps folder: {e}")
                 return {"CANCELLED"}
-        else:
-            self.report({"INFO"}, "No dependencies to uninstall.")
+            # Windows fallback: a still-loaded .pyd/.dll likely holds a lock.
+            # Move the deps dir aside so a fresh install can proceed; the
+            # leftover can be deleted after restarting Blender.
+            leftover = f"{deps_dir}.deleted-{int(time.time())}"
+            try:
+                os.rename(deps_dir, leftover)
+            except OSError:
+                self.report({"ERROR"}, f"Failed to remove deps folder: {e}")
+                return {"CANCELLED"}
+            self.report(
+                {"WARNING"},
+                (
+                    f"Some files were locked and could not be deleted. "
+                    f"Moved deps to '{leftover}'. Restart Blender and "
+                    f"delete that folder to reclaim the disk space."
+                ),
+            )
+            return {"FINISHED"}
 
+        self.report({"INFO"}, "Dependencies uninstalled successfully.")
         return {"FINISHED"}
 
 

--- a/blender_jps/preferences.py
+++ b/blender_jps/preferences.py
@@ -29,7 +29,7 @@ def _handle_rmtree_error(func, path, exc_info):
         os.chmod(path, stat.S_IWRITE)
         func(path)
     except OSError:
-        raise exc_info[1]
+        raise exc_info[1] from None
 
 
 class JUPEDSIM_OT_install_dependencies(bpy.types.Operator):


### PR DESCRIPTION
Evict imported modules from sys.modules before rmtree so Python releases file handles on .pyd/.dll files.  Add onerror handler to chmod read-only files that Windows refuses to delete.

Fixes FabianPlum/BlenderJPS#14