### PR TITLE
[WIP] Multi-floor 3D visualization

### DIFF
--- a/blender_jps/core/geometry.py
+++ b/blender_jps/core/geometry.py
@@ -209,7 +209,7 @@ def create_landing_ramps(landings, levels, collection, mat_cache):
         span = p_max - p_min if p_max > p_min else 1.0
         verts3d = [
             (x, y, z_from + (proj - p_min) / span * (z_to - z_from))
-            for (x, y), proj in zip(coords, projs)
+            for (x, y), proj in zip(coords, projs, strict=True)
         ]
 
         mesh = bpy.data.meshes.new(f"JuPedSim_Ramp_{from_id}_{to_id}_{landing_idx}_Mesh")
@@ -260,8 +260,7 @@ def _normalize_levels_arg(arg):
 def _polygon_parts(geom):
     """Yield each Polygon part of a Polygon or MultiPolygon."""
     if hasattr(geom, "geoms"):  # MultiPolygon
-        for g in geom.geoms:
-            yield g
+        yield from geom.geoms
     else:
         yield geom
 

--- a/blender_jps/core/geometry.py
+++ b/blender_jps/core/geometry.py
@@ -124,6 +124,106 @@ def create_geometry(context, geometry_or_levels, collection, mat_cache):
     return num_curves
 
 
+def create_landing_ramps(landings, levels, collection, mat_cache):
+    """Render each landing as a sloped quad connecting its two slabs.
+
+    A landing has a polygon on the source level (``z_from``) and one on
+    the destination level (``z_to``); in jupedsim's model they overlap
+    in plan. To turn the visual gap between floating slabs into a
+    physical-looking ramp, we slope the landing polygon: vertices on the
+    side closest to the destination level's centroid sit at ``z_to``,
+    the opposite side sits at ``z_from``, and the rest interpolate
+    linearly along that axis.
+
+    Returns the number of ramps created.
+    """
+    if not landings:
+        return 0
+
+    ramp_material = get_or_create_material(
+        mat_cache, "JuPedSim_Ramp_Material", (0.7, 0.55, 0.35, 1.0)
+    )
+
+    level_z = {lvl["id"]: float(lvl["z"]) for lvl in levels}
+    level_centroids = {}
+    for lvl in levels:
+        poly = lvl["polygon"]
+        c = poly.centroid
+        level_centroids[lvl["id"]] = (c.x, c.y)
+
+    count = 0
+    for landing in landings:
+        from_id = landing["from"]
+        to_id = landing["to"]
+        z_from = float(level_z.get(from_id, 0.0))
+        z_to = float(level_z.get(to_id, 0.0))
+        poly = landing["polygon_from"]
+        if poly is None or not hasattr(poly, "exterior"):
+            continue
+        coords = list(poly.exterior.coords)
+        if len(coords) < 3:
+            continue
+        # Open the ring (drop duplicate last vertex) before extracting
+        # vertices for the mesh.
+        if coords[0] == coords[-1]:
+            coords = coords[:-1]
+
+        # Pick the slope direction: from the landing's centroid toward
+        # the destination level's centroid. Falls back to +y if we don't
+        # know the destination centroid.
+        landing_centroid = _polygon_centroid(coords)
+        target_centroid = level_centroids.get(to_id)
+        if target_centroid is None:
+            dx, dy = 0.0, 1.0
+        else:
+            dx = target_centroid[0] - landing_centroid[0]
+            dy = target_centroid[1] - landing_centroid[1]
+            mag = (dx * dx + dy * dy) ** 0.5
+            if mag < 1e-9:
+                dx, dy = 0.0, 1.0
+            else:
+                dx /= mag
+                dy /= mag
+
+        # Project each vertex onto the direction vector; min projection
+        # sits at z_from, max at z_to, the rest interpolate.
+        projs = [(x - landing_centroid[0]) * dx + (y - landing_centroid[1]) * dy
+                 for x, y in coords]
+        p_min = min(projs)
+        p_max = max(projs)
+        span = p_max - p_min if p_max > p_min else 1.0
+        verts3d = [
+            (x, y, z_from + (proj - p_min) / span * (z_to - z_from))
+            for (x, y), proj in zip(coords, projs)
+        ]
+
+        mesh = bpy.data.meshes.new(f"JuPedSim_Ramp_{from_id}_{to_id}_Mesh")
+        bm = bmesh.new()
+        bm_verts = [bm.verts.new(v) for v in verts3d]
+        try:
+            bm.faces.new(bm_verts)
+        except ValueError:
+            # Degenerate (collinear) — skip rather than crash.
+            bm.free()
+            continue
+        bm.to_mesh(mesh)
+        bm.free()
+        ramp = bpy.data.objects.new(f"JuPedSim_Ramp_{from_id}_{to_id}", mesh)
+        assign_material(ramp, ramp_material)
+        collection.objects.link(ramp)
+        count += 1
+    return count
+
+
+def _polygon_centroid(coords):
+    n = len(coords)
+    if n == 0:
+        return (0.0, 0.0)
+    sx = sum(c[0] for c in coords)
+    sy = sum(c[1] for c in coords)
+    return (sx / n, sy / n)
+
+
 def _normalize_levels_arg(arg):
     """Coerce the legacy single-polygon input into the multi-level shape."""
     if isinstance(arg, list) and arg and isinstance(arg[0], dict) and "polygon" in arg[0]:

--- a/blender_jps/core/geometry.py
+++ b/blender_jps/core/geometry.py
@@ -82,11 +82,13 @@ def create_geometry(context, geometry_or_levels, collection, mat_cache):
     num_curves = 0
     for lvl in levels:
         polygon = lvl["polygon"]
+        if polygon is None or polygon.is_empty:
+            continue
+        lvl_bounds = polygon.bounds
+        if not _bounds_finite(lvl_bounds):
+            continue
         z = float(lvl["z"])
         lvl_id = lvl["id"]
-        lvl_bounds = polygon.bounds  # tight bounds per level for the slab
-        if not lvl_bounds:
-            continue
         slab_min_x = lvl_bounds[0] - pad_x * 0.1
         slab_max_x = lvl_bounds[2] + pad_x * 0.1
         slab_min_y = lvl_bounds[1] - pad_y * 0.1
@@ -101,10 +103,12 @@ def create_geometry(context, geometry_or_levels, collection, mat_cache):
             plane_material,
             collection,
         )
-        for poly_part in _polygon_parts(polygon):
+        for part_idx, poly_part in enumerate(_polygon_parts(polygon)):
+            # Include the MultiPolygon part index so multiple boundaries
+            # on the same level are distinguishable in the outliner.
             num_curves += _create_curve_from_coords(
                 context,
-                f"Walkable_Boundary_L{lvl_id}",
+                f"Walkable_Boundary_L{lvl_id}_p{part_idx}",
                 list(poly_part.exterior.coords),
                 collection,
                 mat_cache,
@@ -114,7 +118,7 @@ def create_geometry(context, geometry_or_levels, collection, mat_cache):
             for i, interior in enumerate(poly_part.interiors):
                 num_curves += _create_curve_from_coords(
                     context,
-                    f"Obstacle_L{lvl_id}_{i}",
+                    f"Obstacle_L{lvl_id}_p{part_idx}_{i}",
                     list(interior.coords),
                     collection,
                     mat_cache,
@@ -122,6 +126,17 @@ def create_geometry(context, geometry_or_levels, collection, mat_cache):
                     z=z,
                 )
     return num_curves
+
+
+def _bounds_finite(bounds):
+    """``shapely.Geometry.bounds`` is always a 4-tuple; for empty or
+    degenerate geometries the entries can be NaN/inf. Guard against
+    propagating those into viewport clip / padding math."""
+    import math
+
+    if not bounds or len(bounds) != 4:
+        return False
+    return all(math.isfinite(v) for v in bounds)
 
 
 def create_landing_ramps(landings, levels, collection, mat_cache):
@@ -152,7 +167,7 @@ def create_landing_ramps(landings, levels, collection, mat_cache):
         level_centroids[lvl["id"]] = (c.x, c.y)
 
     count = 0
-    for landing in landings:
+    for landing_idx, landing in enumerate(landings):
         from_id = landing["from"]
         to_id = landing["to"]
         z_from = float(level_z.get(from_id, 0.0))
@@ -197,7 +212,7 @@ def create_landing_ramps(landings, levels, collection, mat_cache):
             for (x, y), proj in zip(coords, projs)
         ]
 
-        mesh = bpy.data.meshes.new(f"JuPedSim_Ramp_{from_id}_{to_id}_Mesh")
+        mesh = bpy.data.meshes.new(f"JuPedSim_Ramp_{from_id}_{to_id}_{landing_idx}_Mesh")
         bm = bmesh.new()
         bm_verts = [bm.verts.new(v) for v in verts3d]
         try:
@@ -208,7 +223,7 @@ def create_landing_ramps(landings, levels, collection, mat_cache):
             continue
         bm.to_mesh(mesh)
         bm.free()
-        ramp = bpy.data.objects.new(f"JuPedSim_Ramp_{from_id}_{to_id}", mesh)
+        ramp = bpy.data.objects.new(f"JuPedSim_Ramp_{from_id}_{to_id}_{landing_idx}", mesh)
         assign_material(ramp, ramp_material)
         collection.objects.link(ramp)
         count += 1
@@ -225,9 +240,19 @@ def _polygon_centroid(coords):
 
 
 def _normalize_levels_arg(arg):
-    """Coerce the legacy single-polygon input into the multi-level shape."""
-    if isinstance(arg, list) and arg and isinstance(arg[0], dict) and "polygon" in arg[0]:
-        return arg
+    """Coerce the legacy single-polygon input into the multi-level shape.
+
+    An empty list is returned as-is (caller short-circuits on no levels);
+    a single shapely Polygon/MultiPolygon (or any object exposing a
+    ``polygon`` attribute) is wrapped into one level at z=0.
+    """
+    if isinstance(arg, list):
+        if not arg:
+            return []
+        if isinstance(arg[0], dict) and "polygon" in arg[0]:
+            return arg
+        # A non-empty list that isn't level dicts is unexpected; fall back
+        # to treating it as not-a-level-list to avoid a confusing crash.
     polygon = arg.polygon if hasattr(arg, "polygon") else arg
     return [{"id": 0, "z": 0.0, "polygon": polygon}]
 
@@ -244,8 +269,11 @@ def _polygon_parts(geom):
 def _combined_bounds(levels):
     out = None
     for lvl in levels:
-        b = lvl["polygon"].bounds
-        if not b:
+        poly = lvl["polygon"]
+        if poly is None or poly.is_empty:
+            continue
+        b = poly.bounds
+        if not _bounds_finite(b):
             continue
         if out is None:
             out = list(b)

--- a/blender_jps/core/geometry.py
+++ b/blender_jps/core/geometry.py
@@ -202,8 +202,7 @@ def create_landing_ramps(landings, levels, collection, mat_cache):
 
         # Project each vertex onto the direction vector; min projection
         # sits at z_from, max at z_to, the rest interpolate.
-        projs = [(x - landing_centroid[0]) * dx + (y - landing_centroid[1]) * dy
-                 for x, y in coords]
+        projs = [(x - landing_centroid[0]) * dx + (y - landing_centroid[1]) * dy for x, y in coords]
         p_min = min(projs)
         p_max = max(projs)
         span = p_max - p_min if p_max > p_min else 1.0

--- a/blender_jps/core/geometry.py
+++ b/blender_jps/core/geometry.py
@@ -43,16 +43,26 @@ def get_or_create_collection(name):
     return collection
 
 
-def create_geometry(context, geometry, collection, mat_cache):
-    """Create curves from the walkable area geometry.
+def create_geometry(context, geometry_or_levels, collection, mat_cache):
+    """Create slabs + boundary curves for the walkable geometry.
 
-    Returns the number of boundary curves created.
+    Accepts either:
+    - A list of level dicts ``[{"id", "z", "polygon"}, ...]`` (v3 multi-
+      floor path), or
+    - A single shapely Polygon/MultiPolygon (legacy v2 path), which is
+      treated as one level at z=0.
+
+    Returns the total number of boundary curves created.
     """
-    polygon = geometry.polygon if hasattr(geometry, "polygon") else geometry
+    levels = _normalize_levels_arg(geometry_or_levels)
 
-    # Ensure viewport clip distance covers the geometry extent
-    bounds = polygon.bounds  # (minx, miny, maxx, maxy)
-    max_dim = max(bounds[2] - bounds[0], bounds[3] - bounds[1])
+    # Compute combined bounds for the viewport clip distance + ground-plane
+    # padding.
+    combined_bounds = _combined_bounds(levels)
+    if combined_bounds is None:
+        return 0
+    minx, miny, maxx, maxy = combined_bounds
+    max_dim = max(maxx - minx, maxy - miny)
     if max_dim > 0:
         for window in context.window_manager.windows:
             for area in window.screen.areas:
@@ -62,57 +72,112 @@ def create_geometry(context, geometry, collection, mat_cache):
                     if space.type == "VIEW_3D" and space.clip_end < max_dim:
                         space.clip_end = max_dim * 4
 
-    # Create a ground plane at origin, expanded 10% beyond geometry bounds.
-    span_x = max(bounds[2] - bounds[0], 0.0)
-    span_y = max(bounds[3] - bounds[1], 0.0)
-    if span_x > 0.0 and span_y > 0.0:
-        pad_x = span_x * 0.1
-        pad_y = span_y * 0.1
-        min_x = bounds[0] - pad_x
-        max_x = bounds[2] + pad_x
-        min_y = bounds[1] - pad_y
-        max_y = bounds[3] + pad_y
+    pad_x = (maxx - minx) * 0.1
+    pad_y = (maxy - miny) * 0.1
 
-        plane_mesh = bpy.data.meshes.new("JuPedSim_Ground_Plane_Mesh")
-        bm = bmesh.new()
-        verts = [
-            bm.verts.new((min_x, min_y, 0.0)),
-            bm.verts.new((max_x, min_y, 0.0)),
-            bm.verts.new((max_x, max_y, 0.0)),
-            bm.verts.new((min_x, max_y, 0.0)),
-        ]
-        bm.faces.new(verts)
-        bm.to_mesh(plane_mesh)
-        bm.free()
-        plane_obj = bpy.data.objects.new("JuPedSim_Ground_Plane", plane_mesh)
-        plane_obj.location = (0.0, 0.0, 0.0)
-        plane_material = get_or_create_material(
-            mat_cache, "JuPedSim_Ground_Plane_Material", (0.85, 0.85, 0.85, 1.0)
-        )
-        assign_material(plane_obj, plane_material)
-        collection.objects.link(plane_obj)
-
-    # Create curves for exterior boundary
-    _create_curve_from_coords(
-        context,
-        "Walkable_Area_Boundary",
-        list(polygon.exterior.coords),
-        collection,
-        mat_cache,
-        closed=True,
+    plane_material = get_or_create_material(
+        mat_cache, "JuPedSim_Ground_Plane_Material", (0.85, 0.85, 0.85, 1.0)
     )
 
-    # Create curves for any interior holes (obstacles)
-    for i, interior in enumerate(polygon.interiors):
-        _create_curve_from_coords(
-            context, f"Obstacle_{i}", list(interior.coords), collection, mat_cache, closed=True
+    num_curves = 0
+    for lvl in levels:
+        polygon = lvl["polygon"]
+        z = float(lvl["z"])
+        lvl_id = lvl["id"]
+        lvl_bounds = polygon.bounds  # tight bounds per level for the slab
+        if not lvl_bounds:
+            continue
+        slab_min_x = lvl_bounds[0] - pad_x * 0.1
+        slab_max_x = lvl_bounds[2] + pad_x * 0.1
+        slab_min_y = lvl_bounds[1] - pad_y * 0.1
+        slab_max_y = lvl_bounds[3] + pad_y * 0.1
+        _create_slab(
+            f"JuPedSim_Level_{lvl_id}",
+            slab_min_x,
+            slab_min_y,
+            slab_max_x,
+            slab_max_y,
+            z,
+            plane_material,
+            collection,
         )
+        for poly_part in _polygon_parts(polygon):
+            num_curves += _create_curve_from_coords(
+                context,
+                f"Walkable_Boundary_L{lvl_id}",
+                list(poly_part.exterior.coords),
+                collection,
+                mat_cache,
+                closed=True,
+                z=z,
+            )
+            for i, interior in enumerate(poly_part.interiors):
+                num_curves += _create_curve_from_coords(
+                    context,
+                    f"Obstacle_L{lvl_id}_{i}",
+                    list(interior.coords),
+                    collection,
+                    mat_cache,
+                    closed=True,
+                    z=z,
+                )
+    return num_curves
 
-    return 1 + len(list(polygon.interiors))
+
+def _normalize_levels_arg(arg):
+    """Coerce the legacy single-polygon input into the multi-level shape."""
+    if isinstance(arg, list) and arg and isinstance(arg[0], dict) and "polygon" in arg[0]:
+        return arg
+    polygon = arg.polygon if hasattr(arg, "polygon") else arg
+    return [{"id": 0, "z": 0.0, "polygon": polygon}]
 
 
-def _create_curve_from_coords(context, name, coords, collection, mat_cache, closed=False):
-    """Create a curve object from a list of coordinates."""
+def _polygon_parts(geom):
+    """Yield each Polygon part of a Polygon or MultiPolygon."""
+    if hasattr(geom, "geoms"):  # MultiPolygon
+        for g in geom.geoms:
+            yield g
+    else:
+        yield geom
+
+
+def _combined_bounds(levels):
+    out = None
+    for lvl in levels:
+        b = lvl["polygon"].bounds
+        if not b:
+            continue
+        if out is None:
+            out = list(b)
+        else:
+            out[0] = min(out[0], b[0])
+            out[1] = min(out[1], b[1])
+            out[2] = max(out[2], b[2])
+            out[3] = max(out[3], b[3])
+    return tuple(out) if out is not None else None
+
+
+def _create_slab(name, min_x, min_y, max_x, max_y, z, material, collection):
+    plane_mesh = bpy.data.meshes.new(f"{name}_Mesh")
+    bm = bmesh.new()
+    verts = [
+        bm.verts.new((min_x, min_y, z)),
+        bm.verts.new((max_x, min_y, z)),
+        bm.verts.new((max_x, max_y, z)),
+        bm.verts.new((min_x, max_y, z)),
+    ]
+    bm.faces.new(verts)
+    bm.to_mesh(plane_mesh)
+    bm.free()
+    plane_obj = bpy.data.objects.new(name, plane_mesh)
+    plane_obj.location = (0.0, 0.0, 0.0)
+    assign_material(plane_obj, material)
+    collection.objects.link(plane_obj)
+    return plane_obj
+
+
+def _create_curve_from_coords(context, name, coords, collection, mat_cache, closed=False, z=0.0):
+    """Create a curve object from a list of coordinates, lifted to ``z``."""
     curve_data = bpy.data.curves.new(name=name, type="CURVE")
     curve_data.dimensions = "3D"
     curve_data.resolution_u = 2
@@ -122,7 +187,7 @@ def _create_curve_from_coords(context, name, coords, collection, mat_cache, clos
 
     for i, coord in enumerate(coords):
         x, y = coord[0], coord[1]
-        spline.points[i].co = (x, y, 0.0, 1.0)
+        spline.points[i].co = (x, y, z, 1.0)
 
     if closed:
         spline.use_cyclic_u = True
@@ -137,7 +202,7 @@ def _create_curve_from_coords(context, name, coords, collection, mat_cache, clos
     curve_data.bevel_depth = context.scene.jupedsim_props.geometry_thickness
     curve_data.bevel_resolution = 2
 
-    return curve_obj
+    return 1
 
 
 _shared_agent_mesh = None

--- a/blender_jps/core/streaming.py
+++ b/blender_jps/core/streaming.py
@@ -8,7 +8,9 @@ import bpy
 
 from ..io.sqlite_reader import query_frame_positions
 
-FrameData = dict[int, list[tuple[int, float, float]]]
+# Each row is ``(id, x, y)`` (legacy HDF5 buffers) or ``(id, x, y, z)``
+# (v3 SQLite buffers); the frame handler normalizes both via _with_z().
+FrameData = dict[int, list[tuple[int, float, float] | tuple[int, float, float, float]]]
 
 STREAM_STATE: dict[str, Any] = {
     "db_path": None,

--- a/blender_jps/core/streaming.py
+++ b/blender_jps/core/streaming.py
@@ -23,7 +23,11 @@ STREAM_STATE: dict[str, Any] = {
     "objects": [],
     "object_name": None,
     "handler_installed": False,
-    "frame_data": None,  # dict: frame_number -> list of (id, x, y) tuples (HDF5 mode)
+    "frame_data": None,  # dict: frame_number -> list of (id, x, y[, z]) tuples (HDF5 mode)
+    # v3 SQLite schema support: ``has_level_col`` tells the reader to
+    # SELECT level alongside x/y, and ``level_z`` maps level id -> world-z.
+    "has_level_col": False,
+    "level_z": {},
 }
 
 
@@ -44,12 +48,20 @@ def stream_frame_handler(scene: bpy.types.Scene) -> None:
         return
 
     if state["frame_data"] is not None:
-        rows = state["frame_data"].get(db_frame, [])
+        raw_rows = state["frame_data"].get(db_frame, [])
+        # HDF5 frame buffers historically carry (id, x, y); normalize to
+        # (id, x, y, z) with z=0 so the rest of the handler is uniform.
+        rows = [_with_z(row) for row in raw_rows]
     else:
         if state["conn"] is None:
             state["conn"] = sqlite3.connect(state["db_path"], isolation_level=None)
             state["cursor"] = state["conn"].cursor()
-        rows = query_frame_positions(state["cursor"], db_frame)
+        rows = query_frame_positions(
+            state["cursor"],
+            db_frame,
+            has_level_col=state["has_level_col"],
+            level_z=state["level_z"],
+        )
 
     if state["mode"] == "big":
         obj = bpy.data.objects.get(state["object_name"])
@@ -60,14 +72,14 @@ def stream_frame_handler(scene: bpy.types.Scene) -> None:
         coords = array("f", [0.0] * (total * 3))
         for i in range(2, len(coords), 3):
             coords[i] = hide_z
-        for agent_id, x, y in rows:
+        for agent_id, x, y, z in rows:
             idx = state["id_to_index"].get(agent_id)
             if idx is None:
                 continue
             base = idx * 3
             coords[base] = float(x)
             coords[base + 1] = float(y)
-            coords[base + 2] = 0.5
+            coords[base + 2] = float(z) + 0.5
         obj.data.vertices.foreach_set("co", coords)
         obj.data.update()
         return
@@ -76,14 +88,22 @@ def stream_frame_handler(scene: bpy.types.Scene) -> None:
     for obj in state["objects"]:
         obj.hide_viewport = True
         obj.hide_render = True
-    for agent_id, x, y in rows:
+    for agent_id, x, y, z in rows:
         idx = state["id_to_index"].get(agent_id)
         if idx is None:
             continue
         obj = state["objects"][idx]
-        obj.location = (float(x), float(y), 0.5)
+        obj.location = (float(x), float(y), float(z) + 0.5)
         obj.hide_viewport = False
         obj.hide_render = False
+
+
+def _with_z(row):
+    """Normalize a frame-buffer row to ``(id, x, y, z)``."""
+    if len(row) == 4:
+        return row
+    agent_id, x, y = row
+    return (agent_id, x, y, 0.0)
 
 
 def start_streaming(
@@ -96,6 +116,8 @@ def start_streaming(
     objects: list[bpy.types.Object] | None = None,
     object_name: str | None = None,
     frame_data: FrameData | None = None,
+    has_level_col: bool = False,
+    level_z: dict[int, float] | None = None,
 ) -> None:
     """Register the frame-change handler and populate streaming state."""
     STREAM_STATE["db_path"] = db_path
@@ -108,6 +130,8 @@ def start_streaming(
     STREAM_STATE["mode"] = mode
     STREAM_STATE["objects"] = objects or []
     STREAM_STATE["object_name"] = object_name
+    STREAM_STATE["has_level_col"] = has_level_col
+    STREAM_STATE["level_z"] = dict(level_z) if level_z else {}
     if not STREAM_STATE["handler_installed"]:
         bpy.app.handlers.frame_change_pre.append(stream_frame_handler)
         STREAM_STATE["handler_installed"] = True
@@ -132,4 +156,6 @@ def clear_stream_state() -> None:
     STREAM_STATE["mode"] = None
     STREAM_STATE["objects"] = []
     STREAM_STATE["object_name"] = None
+    STREAM_STATE["has_level_col"] = False
+    STREAM_STATE["level_z"] = {}
     STREAM_STATE["handler_installed"] = False

--- a/blender_jps/io/sqlite_reader.py
+++ b/blender_jps/io/sqlite_reader.py
@@ -126,15 +126,24 @@ def read_simulation_data(path, frame_step, load_full_paths, cancel_event):
 
 
 def _load_levels_and_landings(cur, version):
-    """Return (levels, landings). v2 files synthesize one level at z=0."""
+    """Return (levels, landings). v2 files (or v3 files whose ``levels``
+    table is missing/corrupt) synthesize one level at z=0 from the legacy
+    ``geometry`` table when possible."""
     import shapely
 
     if version >= 3:
         levels = []
-        for lvl_id, z, wkt in cur.execute("SELECT id, z, wkt FROM levels ORDER BY id ASC"):
-            levels.append(
-                {"id": int(lvl_id), "z": float(z), "polygon": shapely.from_wkt(wkt)}
-            )
+        try:
+            for lvl_id, z, wkt in cur.execute(
+                "SELECT id, z, wkt FROM levels ORDER BY id ASC"
+            ):
+                levels.append(
+                    {"id": int(lvl_id), "z": float(z), "polygon": shapely.from_wkt(wkt)}
+                )
+        except sqlite3.Error:
+            # `levels` table missing despite version=3 — fall through to
+            # the legacy path rather than aborting the whole load.
+            levels = []
         landings = []
         try:
             for from_lvl, to_lvl, p_from, p_to in cur.execute(
@@ -153,9 +162,13 @@ def _load_levels_and_landings(cur, version):
         if levels:
             return levels, landings
 
-    # v2 fallback or missing levels: synthesize one level at z=0 from
-    # whatever the legacy ``geometry`` table holds.
-    res = cur.execute("SELECT wkt FROM geometry").fetchall()
+    # v2 fallback or missing/empty v3 ``levels``: synthesize one level at
+    # z=0 from the legacy ``geometry`` table. If that table is also
+    # missing we hand back an empty result rather than crashing.
+    try:
+        res = cur.execute("SELECT wkt FROM geometry").fetchall()
+    except sqlite3.Error:
+        return [], []
     polygons = [shapely.from_wkt(s[0]) for s in res]
     if polygons:
         merged = shapely.union_all(polygons)

--- a/blender_jps/io/sqlite_reader.py
+++ b/blender_jps/io/sqlite_reader.py
@@ -1,15 +1,53 @@
-"""SQLite reading and parsing for JuPedSim trajectory files."""
+"""SQLite reading and parsing for JuPedSim trajectory files.
+
+Schema versions supported:
+- v2 (legacy): a single ``geometry`` table; all agents implicitly on one
+  flat floor at z=0.
+- v3 (multi-floor): a ``levels(id, z, wkt)`` table, an optional
+  ``landings(...)`` table, and a ``level`` column on
+  ``trajectory_data``. Agents are placed at the elevation of their
+  per-frame level.
+"""
 
 import sqlite3
 import time
 
 
+def _detect_version(cur):
+    """Read metadata.version; returns 1 if the table is missing."""
+    try:
+        row = cur.execute(
+            "SELECT value FROM metadata WHERE key = 'version'"
+        ).fetchone()
+    except sqlite3.Error:
+        return 1
+    if row is None:
+        return 1
+    try:
+        return int(row[0])
+    except (TypeError, ValueError):
+        return 1
+
+
+def _has_column(cur, table, column):
+    rows = cur.execute(f"PRAGMA table_info({table})").fetchall()
+    return any(r[1] == column for r in rows)
+
+
 def read_simulation_data(path, frame_step, load_full_paths, cancel_event):
     """Read metadata, geometry and trajectory data from a JuPedSim SQLite file.
 
-    Designed to run in a worker thread.  Returns ``(data_dict, timings_dict)``
-    on success.  Raises on failure.  Checks *cancel_event* between heavy
-    queries so the caller can abort early.
+    Returns a dict carrying both legacy 2D fields and the new multi-floor
+    fields:
+
+    - ``geometry``: shapely union of all level polygons (back-compat path
+      for the existing single-floor renderer).
+    - ``levels``: list of ``{"id": int, "z": float, "polygon":
+      shapely.Polygon}`` — one entry per level; on v2 files this is a
+      single entry at z=0 derived from the ``geometry`` table.
+    - ``landings``: list of ``{"from": int, "to": int, "polygon_from":
+      shapely.Polygon, "polygon_to": shapely.Polygon}`` — empty on v2.
+    - ``level_z``: ``{level_id: z}`` quick lookup.
     """
     import shapely
 
@@ -25,11 +63,13 @@ def read_simulation_data(path, frame_step, load_full_paths, cancel_event):
             return None, timings
 
         cur = conn.cursor()
+        version = _detect_version(cur)
+        has_level_col = version >= 3 and _has_column(cur, "trajectory_data", "level")
 
         start = time.perf_counter()
-        res = cur.execute("SELECT wkt FROM geometry")
-        geometries = [shapely.from_wkt(s[0]) for s in res.fetchall()]
-        geometry = shapely.union_all(geometries)
+        levels, landings = _load_levels_and_landings(cur, version)
+        geometry = shapely.union_all([lvl["polygon"] for lvl in levels])
+        level_z = {lvl["id"]: lvl["z"] for lvl in levels}
         timings["load_geometry_sqlite"] = time.perf_counter() - start
         if cancel_event.is_set():
             return None, timings
@@ -53,7 +93,7 @@ def read_simulation_data(path, frame_step, load_full_paths, cancel_event):
         path_groups = None
         if load_full_paths:
             start = time.perf_counter()
-            path_groups = _load_full_path_groups(cur, frame_step, min_frame)
+            path_groups = _load_full_path_groups(cur, frame_step, min_frame, has_level_col, level_z)
             timings["load_full_paths"] = time.perf_counter() - start
 
         start = time.perf_counter()
@@ -67,6 +107,11 @@ def read_simulation_data(path, frame_step, load_full_paths, cancel_event):
 
         data = {
             "geometry": geometry,
+            "levels": levels,
+            "landings": landings,
+            "level_z": level_z,
+            "schema_version": version,
+            "has_level_col": has_level_col,
             "agent_ids": agent_ids,
             "min_frame": min_frame,
             "max_frame": max_frame,
@@ -80,29 +125,93 @@ def read_simulation_data(path, frame_step, load_full_paths, cancel_event):
         conn.close()
 
 
-def _load_full_path_groups(cursor, frame_step, min_frame):
-    """Load full path coordinates per agent from an open cursor."""
-    res = cursor.execute(
-        "SELECT id, frame, pos_x, pos_y FROM trajectory_data ORDER BY id ASC, frame ASC"
-    )
-    paths = {}
-    for agent_id, frame, x, y in res.fetchall():
-        if frame_step > 1 and (frame - min_frame) % frame_step != 0:
-            continue
-        paths.setdefault(agent_id, []).append((float(x), float(y), 0.0))
+def _load_levels_and_landings(cur, version):
+    """Return (levels, landings). v2 files synthesize one level at z=0."""
+    import shapely
+
+    if version >= 3:
+        levels = []
+        for lvl_id, z, wkt in cur.execute("SELECT id, z, wkt FROM levels ORDER BY id ASC"):
+            levels.append(
+                {"id": int(lvl_id), "z": float(z), "polygon": shapely.from_wkt(wkt)}
+            )
+        landings = []
+        try:
+            for from_lvl, to_lvl, p_from, p_to in cur.execute(
+                "SELECT from_level, to_level, polygon_from_wkt, polygon_to_wkt FROM landings"
+            ):
+                landings.append(
+                    {
+                        "from": int(from_lvl),
+                        "to": int(to_lvl),
+                        "polygon_from": shapely.from_wkt(p_from),
+                        "polygon_to": shapely.from_wkt(p_to),
+                    }
+                )
+        except sqlite3.Error:
+            pass
+        if levels:
+            return levels, landings
+
+    # v2 fallback or missing levels: synthesize one level at z=0 from
+    # whatever the legacy ``geometry`` table holds.
+    res = cur.execute("SELECT wkt FROM geometry").fetchall()
+    polygons = [shapely.from_wkt(s[0]) for s in res]
+    if polygons:
+        merged = shapely.union_all(polygons)
+        return [{"id": 0, "z": 0.0, "polygon": merged}], []
+    return [], []
+
+
+def _load_full_path_groups(cursor, frame_step, min_frame, has_level_col, level_z):
+    """Load full path coordinates per agent from an open cursor.
+
+    Each emitted point is ``(x, y, z)`` — z derived from the agent's level
+    for v3 files, fixed at 0 for v2.
+    """
+    if has_level_col:
+        res = cursor.execute(
+            "SELECT id, frame, pos_x, pos_y, level FROM trajectory_data "
+            "ORDER BY id ASC, frame ASC"
+        )
+        rows = res.fetchall()
+        paths = {}
+        for agent_id, frame, x, y, level in rows:
+            if frame_step > 1 and (frame - min_frame) % frame_step != 0:
+                continue
+            z = float(level_z.get(level, 0.0))
+            paths.setdefault(agent_id, []).append((float(x), float(y), z))
+    else:
+        res = cursor.execute(
+            "SELECT id, frame, pos_x, pos_y FROM trajectory_data ORDER BY id ASC, frame ASC"
+        )
+        paths = {}
+        for agent_id, frame, x, y in res.fetchall():
+            if frame_step > 1 and (frame - min_frame) % frame_step != 0:
+                continue
+            paths.setdefault(agent_id, []).append((float(x), float(y), 0.0))
     return [(agent_id, coords) for agent_id, coords in paths.items()]
 
 
-def query_frame_positions(cursor, frame):
+def query_frame_positions(cursor, frame, has_level_col=False, level_z=None):
     """Query agent positions for a single frame.
 
-    *cursor* should be a reusable ``sqlite3.Cursor`` kept open for the
-    lifetime of the streaming session.
-
-    Returns a list of ``(id, pos_x, pos_y)`` tuples.
+    Returns a list of ``(id, pos_x, pos_y, z)`` tuples. On legacy v2 files
+    z is always 0; on v3 files it is looked up from the agent's level.
     """
+    if has_level_col:
+        res = cursor.execute(
+            "SELECT id, pos_x, pos_y, level FROM trajectory_data "
+            "WHERE frame == (?) ORDER BY id ASC",
+            (frame,),
+        )
+        lookup = level_z or {}
+        return [
+            (agent_id, x, y, float(lookup.get(level, 0.0)))
+            for agent_id, x, y, level in res.fetchall()
+        ]
     res = cursor.execute(
         "SELECT id, pos_x, pos_y FROM trajectory_data WHERE frame == (?) ORDER BY id ASC",
         (frame,),
     )
-    return res.fetchall()
+    return [(agent_id, x, y, 0.0) for agent_id, x, y in res.fetchall()]

--- a/blender_jps/io/sqlite_reader.py
+++ b/blender_jps/io/sqlite_reader.py
@@ -16,9 +16,7 @@ import time
 def _detect_version(cur):
     """Read metadata.version; returns 1 if the table is missing."""
     try:
-        row = cur.execute(
-            "SELECT value FROM metadata WHERE key = 'version'"
-        ).fetchone()
+        row = cur.execute("SELECT value FROM metadata WHERE key = 'version'").fetchone()
     except sqlite3.Error:
         return 1
     if row is None:
@@ -134,12 +132,8 @@ def _load_levels_and_landings(cur, version):
     if version >= 3:
         levels = []
         try:
-            for lvl_id, z, wkt in cur.execute(
-                "SELECT id, z, wkt FROM levels ORDER BY id ASC"
-            ):
-                levels.append(
-                    {"id": int(lvl_id), "z": float(z), "polygon": shapely.from_wkt(wkt)}
-                )
+            for lvl_id, z, wkt in cur.execute("SELECT id, z, wkt FROM levels ORDER BY id ASC"):
+                levels.append({"id": int(lvl_id), "z": float(z), "polygon": shapely.from_wkt(wkt)})
         except sqlite3.Error:
             # `levels` table missing despite version=3 — fall through to
             # the legacy path rather than aborting the whole load.
@@ -184,8 +178,7 @@ def _load_full_path_groups(cursor, frame_step, min_frame, has_level_col, level_z
     """
     if has_level_col:
         res = cursor.execute(
-            "SELECT id, frame, pos_x, pos_y, level FROM trajectory_data "
-            "ORDER BY id ASC, frame ASC"
+            "SELECT id, frame, pos_x, pos_y, level FROM trajectory_data ORDER BY id ASC, frame ASC"
         )
         rows = res.fetchall()
         paths = {}

--- a/blender_jps/operators.py
+++ b/blender_jps/operators.py
@@ -193,15 +193,29 @@ class JUPEDSIM_OT_load_simulation(Operator):
             self._timed_start("create_geometry")
             # v3 SQLite files carry per-level geometry; pass the list when
             # available so each floor is rendered at its own elevation.
-            geometry_arg = self._worker_data.get("levels") or self._worker_data["geometry"]
+            levels_list = self._worker_data.get("levels")
+            geometry_arg = levels_list or self._worker_data["geometry"]
             num_curves = geo.create_geometry(
                 context,
                 geometry_arg,
                 self._geometry_collection,
                 self._materials,
             )
+            # Render landings as inclined ramps bridging neighboring slabs.
+            # Purely cosmetic — jupedsim treats landings as flat portals.
+            num_ramps = 0
+            if levels_list:
+                num_ramps = geo.create_landing_ramps(
+                    self._worker_data.get("landings", []),
+                    levels_list,
+                    self._geometry_collection,
+                    self._materials,
+                )
             self._timed_end("create_geometry")
-            self.report({"INFO"}, f"Created geometry with {num_curves} boundary curves")
+            self.report(
+                {"INFO"},
+                f"Created geometry with {num_curves} boundary curves and {num_ramps} ramps",
+            )
             props.loading_message = "Creating geometry..."
             props.loading_progress = 25.0
             self._stage = "create_big_data" if self._big_data_mode else "create_agents"

--- a/blender_jps/operators.py
+++ b/blender_jps/operators.py
@@ -191,9 +191,12 @@ class JUPEDSIM_OT_load_simulation(Operator):
         if self._stage == "create_geometry":
             assert self._worker_data is not None
             self._timed_start("create_geometry")
+            # v3 SQLite files carry per-level geometry; pass the list when
+            # available so each floor is rendered at its own elevation.
+            geometry_arg = self._worker_data.get("levels") or self._worker_data["geometry"]
             num_curves = geo.create_geometry(
                 context,
-                self._worker_data["geometry"],
+                geometry_arg,
                 self._geometry_collection,
                 self._materials,
             )
@@ -231,6 +234,8 @@ class JUPEDSIM_OT_load_simulation(Operator):
                 mode="big",
                 object_name=obj_name,
                 frame_data=self._worker_data.get("frame_data"),
+                has_level_col=bool(self._worker_data.get("has_level_col")),
+                level_z=self._worker_data.get("level_z"),
             )
             props.loading_message = "Creating particle points..."
             props.loading_progress = 90.0
@@ -263,6 +268,8 @@ class JUPEDSIM_OT_load_simulation(Operator):
                     mode="default",
                     objects=objects,
                     frame_data=self._worker_data.get("frame_data"),
+                    has_level_col=bool(self._worker_data.get("has_level_col")),
+                    level_z=self._worker_data.get("level_z"),
                 )
             context.scene.frame_set(context.scene.frame_start)
             self._timed_end("finalize")


### PR DESCRIPTION
## Summary

- Detect jupedsim's new sqlite schema (v3) with `levels`, `landings`, and a `level` column on `trajectory_data`. Fall back to the legacy single-floor path on v2 files.
- Render one ground-plane slab + boundary curves per level at its own elevation (z). MultiPolygon-aware.
- Stream agent positions in 3D — z is resolved from each row's `level` via the `level_z` map, so an agent walking F1 → stair → F2 actually moves up.
- Render each landing as a sloped quad bridging its two slabs (purely cosmetic — jupedsim treats landings as flat portals). Slope direction is inferred from the destination level's centroid.

## Schema this consumes (jupedsim side)

The matching jupedsim change ships in branch `multi-story-routing` (PR pending) and bumps `DATABASE_VERSION` to 3. See [`sqlite_serialization.py` in jupedsim](https://github.com/PedestrianDynamics/jupedsim) once merged.

A v3 file carries:

```sql
levels(id INTEGER PRIMARY KEY, z REAL, wkt TEXT)
landings(from_level, to_level, polygon_from_wkt, polygon_to_wkt)
trajectory_data(..., level INTEGER NOT NULL DEFAULT 0)
```

A sample `two_floors.sqlite` (one agent walking floor 1 → stair → floor 2) is attached in the comments below.

## Back-compat

- v2 files still load: `_load_levels_and_landings` synthesizes one level at z=0 from the legacy `geometry` table.
- `query_frame_positions` falls back to `(id, x, y, 0.0)` when there's no `level` column.
- HDF5 path unchanged; `_with_z()` pads `(id, x, y)` rows to `(id, x, y, 0.0)`.

## Test plan

- [x] Headless reader test on a v3 `two_floors.sqlite`: 3 levels read with z={0, 3.0, 1.5}, 2 landings, agent path covers z ∈ {0, 1.5, 3.0}.
- [x] Manual visual smoke in Blender 5.0: two square slabs (z=0, z=3), small stair plate (z=1.5), two brown ramps bridging the gaps; one agent sphere walks through all three.
- [ ] Visual smoke on a legacy v2 file (regression check).
- [ ] Big-data mode visual smoke on a v3 file.