### PR TITLE
Add navmesh + interactive router debug visualization

### DIFF
--- a/blender_jps/__init__.py
+++ b/blender_jps/__init__.py
@@ -36,6 +36,17 @@ from bpy.types import PropertyGroup
 
 # Import submodules
 from . import operators, panels, preferences
+from .core import navmesh as _navmesh
+
+
+@bpy.app.handlers.persistent
+def _on_load_post(_dummy):
+    """Drop the navmesh routing-engine cache when a new .blend is opened.
+
+    Without this the module-level cache would happily serve engines
+    built against the previous file's geometry.
+    """
+    _navmesh.clear_engines()
 
 
 def update_path_visibility(self, context):
@@ -188,11 +199,17 @@ def register():
     # Add properties to scene
     bpy.types.Scene.jupedsim_props = PointerProperty(type=JuPedSimProperties)
 
+    if _on_load_post not in bpy.app.handlers.load_post:
+        bpy.app.handlers.load_post.append(_on_load_post)
+
     print("BlenderJPS addon registered successfully")
 
 
 def unregister():
     """Unregister the addon."""
+    if _on_load_post in bpy.app.handlers.load_post:
+        bpy.app.handlers.load_post.remove(_on_load_post)
+
     # Remove properties from scene
     del bpy.types.Scene.jupedsim_props
 

--- a/blender_jps/__init__.py
+++ b/blender_jps/__init__.py
@@ -28,7 +28,6 @@ import bpy
 from bpy.props import (
     BoolProperty,
     FloatProperty,
-    FloatVectorProperty,
     IntProperty,
     PointerProperty,
     StringProperty,
@@ -166,22 +165,6 @@ class JuPedSimProperties(PropertyGroup):
         description="Level id whose RoutingEngine to query",
         default=0,
         min=0,
-    )
-
-    route_from: FloatVectorProperty(
-        name="Route From",
-        description="World XY of the route source point",
-        size=2,
-        default=(0.0, 0.0),
-        subtype="XYZ",
-    )
-
-    route_to: FloatVectorProperty(
-        name="Route To",
-        description="World XY of the route target point",
-        size=2,
-        default=(0.0, 0.0),
-        subtype="XYZ",
     )
 
 

--- a/blender_jps/__init__.py
+++ b/blender_jps/__init__.py
@@ -28,6 +28,7 @@ import bpy
 from bpy.props import (
     BoolProperty,
     FloatProperty,
+    FloatVectorProperty,
     IntProperty,
     PointerProperty,
     StringProperty,
@@ -158,6 +159,29 @@ class JuPedSimProperties(PropertyGroup):
         default=0,
         min=0,
         options={"HIDDEN"},
+    )
+
+    route_level: IntProperty(
+        name="Route Level",
+        description="Level id whose RoutingEngine to query",
+        default=0,
+        min=0,
+    )
+
+    route_from: FloatVectorProperty(
+        name="Route From",
+        description="World XY of the route source point",
+        size=2,
+        default=(0.0, 0.0),
+        subtype="XYZ",
+    )
+
+    route_to: FloatVectorProperty(
+        name="Route To",
+        description="World XY of the route target point",
+        size=2,
+        default=(0.0, 0.0),
+        subtype="XYZ",
     )
 
 

--- a/blender_jps/core/navmesh.py
+++ b/blender_jps/core/navmesh.py
@@ -81,10 +81,11 @@ def create_navmesh_objects(
     if not _engines:
         return 0
 
-    # Muted slate-blue: distinguishable from the dark geometry curves
-    # without competing for attention.
+    # Slate blue — distinguishable from the dark geometry boundaries
+    # without competing for attention. Saturated enough to read in both
+    # Material and Object viewport color modes.
     material = get_or_create_material(
-        mat_cache, "JuPedSim_Navmesh_Material", (0.35, 0.5, 0.65, 1.0)
+        mat_cache, "JuPedSim_Navmesh_Material", (0.25, 0.45, 0.75, 1.0)
     )
     level_z = {int(lvl["id"]): float(lvl["z"]) for lvl in nav_levels}
 
@@ -119,9 +120,12 @@ def _build_navmesh_object(level_id, engine, z, material, collection):
     # would draw in the theme's wire color and look identical to the
     # geometry boundaries.
     mod = obj.modifiers.new(name="Wireframe", type="WIREFRAME")
-    mod.thickness = 0.03
+    mod.thickness = 0.08
     mod.use_replace = True
     mod.use_even_offset = False
+    # Mirror the material color into obj.color so users with viewport
+    # shading set to "Object" color also see the tint.
+    obj.color = (0.25, 0.45, 0.75, 1.0)
     obj.hide_render = True
     collection.objects.link(obj)
     return obj
@@ -299,6 +303,30 @@ def remove_live_route():
         obj = bpy.data.objects.get(n)
         if obj is not None:
             bpy.data.objects.remove(obj, do_unlink=True)
+
+
+def commit_live_route(level_id: int, collection: bpy.types.Collection) -> bool:
+    """Promote the live route + endpoints to numbered persistent objects.
+
+    Returns True if a live route existed and was renamed; False otherwise.
+    """
+    live = bpy.data.objects.get(LIVE_ROUTE_NAME)
+    if live is None or live.hide_viewport:
+        return False
+    base = _next_route_name(collection, level_id)
+    rename_map = {
+        LIVE_ROUTE_NAME: base,
+        LIVE_FROM_NAME: base + "_From",
+        LIVE_TO_NAME: base + "_To",
+    }
+    for old, new in rename_map.items():
+        obj = bpy.data.objects.get(old)
+        if obj is None:
+            continue
+        obj.name = new
+        if obj.data is not None:
+            obj.data.name = new + "_Mesh" if obj.type == "MESH" else new
+    return True
 
 
 def clear_navmesh_objects(collection: bpy.types.Collection) -> int:

--- a/blender_jps/core/navmesh.py
+++ b/blender_jps/core/navmesh.py
@@ -81,23 +81,26 @@ def create_navmesh_objects(
     if not _engines:
         return 0
 
-    # Slate blue — distinguishable from the dark geometry boundaries
-    # without competing for attention. Saturated enough to read in both
-    # Material and Object viewport color modes.
-    material = get_or_create_material(
-        mat_cache, "JuPedSim_Navmesh_Material", (0.25, 0.45, 0.75, 1.0)
-    )
+    # Vivid blue — saturated enough to still read as blue once Workbench
+    # studio lighting darkens the side facets of the wireframe tubes.
+    color = (0.1, 0.45, 1.0, 1.0)
+    material = get_or_create_material(mat_cache, "JuPedSim_Navmesh_Material", color)
+    # Matte and non-metallic so the studio matcap doesn't put a white
+    # specular highlight on top of the tint.
+    material.metallic = 0.0
+    material.roughness = 1.0
+    material.specular_intensity = 0.0
     level_z = {int(lvl["id"]): float(lvl["z"]) for lvl in nav_levels}
 
     count = 0
     for level_id, engine in _engines.items():
         z = level_z.get(level_id, 0.0) + _NAVMESH_Z_OFFSET
-        if _build_navmesh_object(level_id, engine, z, material, collection) is not None:
+        if _build_navmesh_object(level_id, engine, z, material, color, collection) is not None:
             count += 1
     return count
 
 
-def _build_navmesh_object(level_id, engine, z, material, collection):
+def _build_navmesh_object(level_id, engine, z, material, color, collection):
     try:
         verts2d, polys = engine.mesh()
     except Exception as exc:  # noqa: BLE001
@@ -120,12 +123,14 @@ def _build_navmesh_object(level_id, engine, z, material, collection):
     # would draw in the theme's wire color and look identical to the
     # geometry boundaries.
     mod = obj.modifiers.new(name="Wireframe", type="WIREFRAME")
-    mod.thickness = 0.08
+    # Thin enough that side facets are barely visible from any angle —
+    # what you see is the top facet's color, not the shaded sides.
+    mod.thickness = 0.04
     mod.use_replace = True
     mod.use_even_offset = False
     # Mirror the material color into obj.color so users with viewport
     # shading set to "Object" color also see the tint.
-    obj.color = (0.25, 0.45, 0.75, 1.0)
+    obj.color = color
     obj.hide_render = True
     collection.objects.link(obj)
     return obj

--- a/blender_jps/core/navmesh.py
+++ b/blender_jps/core/navmesh.py
@@ -48,6 +48,13 @@ def available_levels() -> list[int]:
     return sorted(_engines.keys())
 
 
+def is_routable(level_id: int, xy: tuple[float, float]) -> bool:
+    engine = _engines.get(int(level_id))
+    if engine is None:
+        return False
+    return bool(engine.is_routable(xy))
+
+
 def build_routing_engines(nav_levels: list[dict]) -> dict[int, Any]:
     """Build one :class:`RoutingEngine` per level.
 
@@ -136,64 +143,6 @@ def _build_navmesh_object(level_id, engine, z, material, color, collection):
     return obj
 
 
-def compute_route_curve(
-    level_id: int,
-    from_xy: tuple[float, float],
-    to_xy: tuple[float, float],
-    z: float,
-    collection: bpy.types.Collection,
-    mat_cache: dict,
-) -> tuple[object | None, float, str | None]:
-    """Compute a path on the cached engine and render it as a curve.
-
-    Returns ``(curve_obj, length, error_message)``. ``curve_obj`` is None
-    when the query couldn't be served; ``error_message`` describes why.
-    """
-    engine = _engines.get(int(level_id))
-    if engine is None:
-        return None, 0.0, f"No routing engine for level {level_id}"
-
-    if not engine.is_routable(from_xy):
-        return None, 0.0, f"From point {from_xy} is not in the walkable area"
-    if not engine.is_routable(to_xy):
-        return None, 0.0, f"To point {to_xy} is not in the walkable area"
-
-    try:
-        waypoints = engine.compute_waypoints(from_xy, to_xy)
-    except Exception as exc:  # noqa: BLE001
-        return None, 0.0, f"compute_waypoints failed: {exc}"
-
-    if len(waypoints) < 2:
-        return None, 0.0, "Router returned an empty path"
-
-    length = 0.0
-    for a, b in zip(waypoints[:-1], waypoints[1:], strict=True):
-        length += math.hypot(a[0] - b[0], a[1] - b[1])
-
-    name = _next_route_name(collection, level_id)
-    curve_data = bpy.data.curves.new(name=name, type="CURVE")
-    curve_data.dimensions = "3D"
-    curve_data.resolution_u = 2
-    spline = curve_data.splines.new("POLY")
-    spline.points.add(len(waypoints) - 1)
-    route_z = z + _ROUTE_Z_OFFSET
-    for i, pt in enumerate(waypoints):
-        spline.points[i].co = (float(pt[0]), float(pt[1]), route_z, 1.0)
-    spline.use_cyclic_u = False
-    curve_data.bevel_depth = 0.05
-    curve_data.bevel_resolution = 2
-
-    material = get_or_create_material(mat_cache, "JuPedSim_Route_Material", (1.0, 0.05, 0.05, 1.0))
-    curve_obj = bpy.data.objects.new(name, curve_data)
-    assign_material(curve_obj, material)
-    collection.objects.link(curve_obj)
-
-    _add_route_endpoint(name + "_From", from_xy, route_z, collection, material)
-    _add_route_endpoint(name + "_To", to_xy, route_z, collection, material)
-
-    return curve_obj, length, None
-
-
 def _next_route_name(collection, level_id):
     """Avoid clobbering prior routes — they're cheap and useful side-by-side."""
     n = 0
@@ -204,18 +153,6 @@ def _next_route_name(collection, level_id):
     return f"{prefix}{n}"
 
 
-def _add_route_endpoint(name, xy, z, collection, material):
-    mesh = bpy.data.meshes.new(f"{name}_Mesh")
-    bm = bmesh.new()
-    bmesh.ops.create_uvsphere(bm, u_segments=12, v_segments=8, radius=0.15)
-    bm.to_mesh(mesh)
-    bm.free()
-    obj = bpy.data.objects.new(name, mesh)
-    obj.location = (float(xy[0]), float(xy[1]), float(z))
-    assign_material(obj, material)
-    collection.objects.link(obj)
-
-
 def update_live_route(
     level_id: int,
     from_xy: tuple[float, float],
@@ -223,8 +160,12 @@ def update_live_route(
     z: float,
     collection: bpy.types.Collection,
     mat_cache: dict,
+    from_routable: bool | None = None,
 ) -> tuple[float | None, str | None]:
     """Replace the single live-route curve in place. Cheap to call per mousemove.
+
+    Pass ``from_routable`` to skip re-checking ``is_routable(from_xy)``
+    on the hot path — the source doesn't move during a drag.
 
     Returns ``(length, error)``. ``length`` is None when the query was
     rejected (out of walkable area, empty path); the curve is hidden in
@@ -234,7 +175,9 @@ def update_live_route(
     if engine is None:
         return None, f"No routing engine for level {level_id}"
 
-    if not engine.is_routable(from_xy) or not engine.is_routable(to_xy):
+    if from_routable is None:
+        from_routable = bool(engine.is_routable(from_xy))
+    if not from_routable or not engine.is_routable(to_xy):
         _hide_live_route()
         return None, None
 
@@ -270,6 +213,8 @@ def _set_live_route_curve(waypoints, route_z, collection, material):
         curve_data.bevel_resolution = 2
         obj = bpy.data.objects.new(LIVE_ROUTE_NAME, curve_data)
         assign_material(obj, material)
+        # Debug overlay — must not bleed into final renders.
+        obj.hide_render = True
         collection.objects.link(obj)
     curve_data = obj.data
     curve_data.splines.clear()
@@ -291,6 +236,7 @@ def _set_live_endpoint(name, xy, z, collection, material):
         bm.free()
         obj = bpy.data.objects.new(name, mesh)
         assign_material(obj, material)
+        obj.hide_render = True
         collection.objects.link(obj)
     obj.location = (float(xy[0]), float(xy[1]), float(z))
     obj.hide_viewport = False
@@ -307,7 +253,23 @@ def remove_live_route():
     for n in (LIVE_ROUTE_NAME, LIVE_FROM_NAME, LIVE_TO_NAME):
         obj = bpy.data.objects.get(n)
         if obj is not None:
-            bpy.data.objects.remove(obj, do_unlink=True)
+            _remove_object_with_data(obj)
+
+
+def _remove_object_with_data(obj) -> None:
+    """Remove an object and free its mesh/curve datablock.
+
+    Without this the per-pick endpoint meshes and curves linger as
+    orphan data and accumulate over a session.
+    """
+    data = obj.data
+    bpy.data.objects.remove(obj, do_unlink=True)
+    if data is None or data.users:
+        return
+    if isinstance(data, bpy.types.Mesh):
+        bpy.data.meshes.remove(data)
+    elif isinstance(data, bpy.types.Curve):
+        bpy.data.curves.remove(data)
 
 
 def commit_live_route(level_id: int, collection: bpy.types.Collection) -> bool:
@@ -339,7 +301,7 @@ def clear_navmesh_objects(collection: bpy.types.Collection) -> int:
     n = 0
     for obj in list(collection.objects):
         if obj.name.startswith("JuPedSim_Navmesh_"):
-            bpy.data.objects.remove(obj, do_unlink=True)
+            _remove_object_with_data(obj)
             n += 1
     return n
 
@@ -349,7 +311,7 @@ def clear_routes(collection: bpy.types.Collection) -> int:
     n = 0
     for obj in list(collection.objects):
         if obj.name.startswith("Route_"):
-            bpy.data.objects.remove(obj, do_unlink=True)
+            _remove_object_with_data(obj)
             n += 1
     return n
 

--- a/blender_jps/core/navmesh.py
+++ b/blender_jps/core/navmesh.py
@@ -23,8 +23,8 @@ import bpy
 
 from .geometry import assign_material, get_or_create_material
 
-NAVMESH_COLLECTION = "JuPedSim_Geometry"
-ROUTE_COLLECTION = "JuPedSim_Geometry"
+NAVMESH_COLLECTION = "JuPedSim_Navmesh"
+ROUTE_COLLECTION = "JuPedSim_Routes"
 LIVE_ROUTE_NAME = "Route_Live"
 LIVE_FROM_NAME = "Route_Live_From"
 LIVE_TO_NAME = "Route_Live_To"

--- a/blender_jps/core/navmesh.py
+++ b/blender_jps/core/navmesh.py
@@ -34,10 +34,19 @@ _NAVMESH_Z_OFFSET = 0.02
 _ROUTE_Z_OFFSET = 0.05
 
 _engines: dict[int, Any] = {}
+# Single source of truth for per-level z. Both the navmesh objects and
+# the route picker read from here so they can't drift apart.
+_level_z: dict[int, float] = {}
 
 
 def clear_engines() -> None:
     _engines.clear()
+    _level_z.clear()
+
+
+def level_z(level_id: int) -> float:
+    """Return the z of a built level, or 0.0 if the level isn't loaded."""
+    return _level_z.get(int(level_id), 0.0)
 
 
 def get_engine(level_id: int) -> object | None:
@@ -72,8 +81,10 @@ def build_routing_engines(nav_levels: list[dict]) -> dict[int, Any]:
         polygon = lvl.get("polygon")
         if polygon is None or polygon.is_empty:
             continue
+        lvl_id = int(lvl["id"])
         try:
-            _engines[int(lvl["id"])] = RoutingEngine(polygon)
+            _engines[lvl_id] = RoutingEngine(polygon)
+            _level_z[lvl_id] = float(lvl.get("z", 0.0))
         except Exception as exc:  # noqa: BLE001 — surface but don't abort
             print(f"[BlenderJPS] navmesh: skipping level {lvl.get('id')}: {exc}")
     return dict(_engines)
@@ -144,13 +155,25 @@ def _build_navmesh_object(level_id, engine, z, material, color, collection):
 
 
 def _next_route_name(collection, level_id):
-    """Avoid clobbering prior routes — they're cheap and useful side-by-side."""
-    n = 0
+    """Pick the next free ``Route_L{lvl}_<n>`` suffix.
+
+    Counting wouldn't work: after deleting a middle route Blender would
+    suffix the new object with ``.001`` to avoid the collision. Scan
+    existing suffixes and pick max+1 instead.
+    """
     prefix = f"Route_L{level_id}_"
+    highest = -1
     for obj in collection.objects:
-        if obj.name.startswith(prefix):
-            n += 1
-    return f"{prefix}{n}"
+        if not obj.name.startswith(prefix):
+            continue
+        tail = obj.name[len(prefix) :].split("_", 1)[0]
+        try:
+            n = int(tail)
+        except ValueError:
+            continue
+        if n > highest:
+            highest = n
+    return f"{prefix}{highest + 1}"
 
 
 def update_live_route(

--- a/blender_jps/core/navmesh.py
+++ b/blender_jps/core/navmesh.py
@@ -81,8 +81,10 @@ def create_navmesh_objects(
     if not _engines:
         return 0
 
+    # Muted slate-blue: distinguishable from the dark geometry curves
+    # without competing for attention.
     material = get_or_create_material(
-        mat_cache, "JuPedSim_Navmesh_Material", (0.95, 0.55, 0.2, 1.0)
+        mat_cache, "JuPedSim_Navmesh_Material", (0.35, 0.5, 0.65, 1.0)
     )
     level_z = {int(lvl["id"]): float(lvl["z"]) for lvl in nav_levels}
 
@@ -111,12 +113,16 @@ def _build_navmesh_object(level_id, engine, z, material, collection):
     mesh.update()
 
     obj = bpy.data.objects.new(name, mesh)
-    # Edges-only — keeps the slab/agents visible under the triangulation,
-    # matching jupedsim_visualizer's look.
-    obj.display_type = "WIRE"
-    obj.show_all_edges = True
-    obj.hide_render = True
     assign_material(obj, material)
+    # Wireframe modifier turns each edge into a thin tube so the material
+    # color actually shows in solid viewport shading — display_type='WIRE'
+    # would draw in the theme's wire color and look identical to the
+    # geometry boundaries.
+    mod = obj.modifiers.new(name="Wireframe", type="WIREFRAME")
+    mod.thickness = 0.03
+    mod.use_replace = True
+    mod.use_even_offset = False
+    obj.hide_render = True
     collection.objects.link(obj)
     return obj
 

--- a/blender_jps/core/navmesh.py
+++ b/blender_jps/core/navmesh.py
@@ -25,6 +25,9 @@ from .geometry import assign_material, get_or_create_material
 
 NAVMESH_COLLECTION = "JuPedSim_Navmesh"
 ROUTE_COLLECTION = "JuPedSim_Routes"
+LIVE_ROUTE_NAME = "Route_Live"
+LIVE_FROM_NAME = "Route_Live_From"
+LIVE_TO_NAME = "Route_Live_To"
 
 # Sit just above the slab so wire edges are visible without z-fighting.
 _NAVMESH_Z_OFFSET = 0.02
@@ -195,11 +198,105 @@ def _add_route_endpoint(name, xy, z, collection, material):
     collection.objects.link(obj)
 
 
+def update_live_route(
+    level_id: int,
+    from_xy: tuple[float, float],
+    to_xy: tuple[float, float],
+    z: float,
+    collection: bpy.types.Collection,
+    mat_cache: dict,
+) -> tuple[float | None, str | None]:
+    """Replace the single live-route curve in place. Cheap to call per mousemove.
+
+    Returns ``(length, error)``. ``length`` is None when the query was
+    rejected (out of walkable area, empty path); the curve is hidden in
+    that case rather than removed, so toggling stays smooth.
+    """
+    engine = _engines.get(int(level_id))
+    if engine is None:
+        return None, f"No routing engine for level {level_id}"
+
+    if not engine.is_routable(from_xy) or not engine.is_routable(to_xy):
+        _hide_live_route()
+        return None, None
+
+    try:
+        waypoints = engine.compute_waypoints(from_xy, to_xy)
+    except Exception as exc:  # noqa: BLE001
+        _hide_live_route()
+        return None, f"compute_waypoints failed: {exc}"
+
+    if len(waypoints) < 2:
+        _hide_live_route()
+        return None, None
+
+    length = 0.0
+    for a, b in zip(waypoints[:-1], waypoints[1:], strict=True):
+        length += math.hypot(a[0] - b[0], a[1] - b[1])
+
+    route_z = z + _ROUTE_Z_OFFSET
+    material = get_or_create_material(mat_cache, "JuPedSim_Route_Material", (1.0, 0.05, 0.05, 1.0))
+    _set_live_route_curve(waypoints, route_z, collection, material)
+    _set_live_endpoint(LIVE_FROM_NAME, from_xy, route_z, collection, material)
+    _set_live_endpoint(LIVE_TO_NAME, to_xy, route_z, collection, material)
+    return length, None
+
+
+def _set_live_route_curve(waypoints, route_z, collection, material):
+    obj = bpy.data.objects.get(LIVE_ROUTE_NAME)
+    if obj is None or obj.type != "CURVE":
+        curve_data = bpy.data.curves.new(name=LIVE_ROUTE_NAME, type="CURVE")
+        curve_data.dimensions = "3D"
+        curve_data.resolution_u = 2
+        curve_data.bevel_depth = 0.05
+        curve_data.bevel_resolution = 2
+        obj = bpy.data.objects.new(LIVE_ROUTE_NAME, curve_data)
+        assign_material(obj, material)
+        collection.objects.link(obj)
+    curve_data = obj.data
+    curve_data.splines.clear()
+    spline = curve_data.splines.new("POLY")
+    spline.points.add(len(waypoints) - 1)
+    for i, pt in enumerate(waypoints):
+        spline.points[i].co = (float(pt[0]), float(pt[1]), route_z, 1.0)
+    spline.use_cyclic_u = False
+    obj.hide_viewport = False
+
+
+def _set_live_endpoint(name, xy, z, collection, material):
+    obj = bpy.data.objects.get(name)
+    if obj is None or obj.type != "MESH":
+        mesh = bpy.data.meshes.new(f"{name}_Mesh")
+        bm = bmesh.new()
+        bmesh.ops.create_uvsphere(bm, u_segments=12, v_segments=8, radius=0.15)
+        bm.to_mesh(mesh)
+        bm.free()
+        obj = bpy.data.objects.new(name, mesh)
+        assign_material(obj, material)
+        collection.objects.link(obj)
+    obj.location = (float(xy[0]), float(xy[1]), float(z))
+    obj.hide_viewport = False
+
+
+def _hide_live_route():
+    for n in (LIVE_ROUTE_NAME, LIVE_FROM_NAME, LIVE_TO_NAME):
+        obj = bpy.data.objects.get(n)
+        if obj is not None:
+            obj.hide_viewport = True
+
+
+def remove_live_route():
+    for n in (LIVE_ROUTE_NAME, LIVE_FROM_NAME, LIVE_TO_NAME):
+        obj = bpy.data.objects.get(n)
+        if obj is not None:
+            bpy.data.objects.remove(obj, do_unlink=True)
+
+
 def clear_routes(collection: bpy.types.Collection) -> int:
     """Remove all ``Route_*`` objects from a collection. Returns count."""
     n = 0
     for obj in list(collection.objects):
-        if obj.name.startswith("Route_L"):
+        if obj.name.startswith("Route_"):
             bpy.data.objects.remove(obj, do_unlink=True)
             n += 1
     return n

--- a/blender_jps/core/navmesh.py
+++ b/blender_jps/core/navmesh.py
@@ -23,8 +23,8 @@ import bpy
 
 from .geometry import assign_material, get_or_create_material
 
-NAVMESH_COLLECTION = "JuPedSim_Navmesh"
-ROUTE_COLLECTION = "JuPedSim_Routes"
+NAVMESH_COLLECTION = "JuPedSim_Geometry"
+ROUTE_COLLECTION = "JuPedSim_Geometry"
 LIVE_ROUTE_NAME = "Route_Live"
 LIVE_FROM_NAME = "Route_Live_From"
 LIVE_TO_NAME = "Route_Live_To"
@@ -111,8 +111,11 @@ def _build_navmesh_object(level_id, engine, z, material, collection):
     mesh.update()
 
     obj = bpy.data.objects.new(name, mesh)
-    obj.show_wire = True
+    # Edges-only — keeps the slab/agents visible under the triangulation,
+    # matching jupedsim_visualizer's look.
+    obj.display_type = "WIRE"
     obj.show_all_edges = True
+    obj.hide_render = True
     assign_material(obj, material)
     collection.objects.link(obj)
     return obj
@@ -290,6 +293,16 @@ def remove_live_route():
         obj = bpy.data.objects.get(n)
         if obj is not None:
             bpy.data.objects.remove(obj, do_unlink=True)
+
+
+def clear_navmesh_objects(collection: bpy.types.Collection) -> int:
+    """Remove all navmesh wireframe objects from a collection."""
+    n = 0
+    for obj in list(collection.objects):
+        if obj.name.startswith("JuPedSim_Navmesh_"):
+            bpy.data.objects.remove(obj, do_unlink=True)
+            n += 1
+    return n
 
 
 def clear_routes(collection: bpy.types.Collection) -> int:

--- a/blender_jps/core/navmesh.py
+++ b/blender_jps/core/navmesh.py
@@ -1,0 +1,221 @@
+"""Navigation mesh + router debug visualization.
+
+Wraps :class:`jupedsim.RoutingEngine` so we can render the triangulation
+that jupedsim's router actually uses, and draw the waypoints it would
+produce for an arbitrary (from, to) query.
+
+Designed around a list of ``NavLevel`` dicts so single-floor and
+multi-floor inputs share the same code path:
+
+    NavLevel = {"id": int, "z": float, "polygon": shapely.(Multi)Polygon}
+
+Engines are cached at module scope keyed by level id; clear them on
+reload via :func:`clear_engines`.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import bmesh
+import bpy
+
+from .geometry import assign_material, get_or_create_material
+
+NAVMESH_COLLECTION = "JuPedSim_Navmesh"
+ROUTE_COLLECTION = "JuPedSim_Routes"
+
+# Sit just above the slab so wire edges are visible without z-fighting.
+_NAVMESH_Z_OFFSET = 0.02
+_ROUTE_Z_OFFSET = 0.05
+
+_engines: dict[int, Any] = {}
+
+
+def clear_engines() -> None:
+    _engines.clear()
+
+
+def get_engine(level_id: int) -> object | None:
+    return _engines.get(level_id)
+
+
+def available_levels() -> list[int]:
+    return sorted(_engines.keys())
+
+
+def build_routing_engines(nav_levels: list[dict]) -> dict[int, Any]:
+    """Build one :class:`RoutingEngine` per level.
+
+    Silent no-op if jupedsim isn't importable — the navmesh feature is
+    optional and shouldn't break the main load path.
+    """
+    try:
+        from jupedsim import RoutingEngine
+    except ImportError:
+        clear_engines()
+        return {}
+
+    clear_engines()
+    for lvl in nav_levels:
+        polygon = lvl.get("polygon")
+        if polygon is None or polygon.is_empty:
+            continue
+        try:
+            _engines[int(lvl["id"])] = RoutingEngine(polygon)
+        except Exception as exc:  # noqa: BLE001 — surface but don't abort
+            print(f"[BlenderJPS] navmesh: skipping level {lvl.get('id')}: {exc}")
+    return dict(_engines)
+
+
+def create_navmesh_objects(
+    nav_levels: list[dict],
+    collection: bpy.types.Collection,
+    mat_cache: dict,
+) -> int:
+    """Materialize the cached engines as wireframe meshes, one per level."""
+    if not _engines:
+        return 0
+
+    material = get_or_create_material(
+        mat_cache, "JuPedSim_Navmesh_Material", (0.95, 0.55, 0.2, 1.0)
+    )
+    level_z = {int(lvl["id"]): float(lvl["z"]) for lvl in nav_levels}
+
+    count = 0
+    for level_id, engine in _engines.items():
+        z = level_z.get(level_id, 0.0) + _NAVMESH_Z_OFFSET
+        if _build_navmesh_object(level_id, engine, z, material, collection) is not None:
+            count += 1
+    return count
+
+
+def _build_navmesh_object(level_id, engine, z, material, collection):
+    try:
+        verts2d, polys = engine.mesh()
+    except Exception as exc:  # noqa: BLE001
+        print(f"[BlenderJPS] navmesh: mesh() failed on level {level_id}: {exc}")
+        return None
+    if not verts2d or not polys:
+        return None
+
+    name = f"JuPedSim_Navmesh_L{level_id}"
+    mesh = bpy.data.meshes.new(f"{name}_Mesh")
+    verts3d = [(float(v[0]), float(v[1]), z) for v in verts2d]
+    faces = [list(map(int, p)) for p in polys if len(p) >= 3]
+    mesh.from_pydata(verts3d, [], faces)
+    mesh.update()
+
+    obj = bpy.data.objects.new(name, mesh)
+    obj.show_wire = True
+    obj.show_all_edges = True
+    assign_material(obj, material)
+    collection.objects.link(obj)
+    return obj
+
+
+def compute_route_curve(
+    level_id: int,
+    from_xy: tuple[float, float],
+    to_xy: tuple[float, float],
+    z: float,
+    collection: bpy.types.Collection,
+    mat_cache: dict,
+) -> tuple[object | None, float, str | None]:
+    """Compute a path on the cached engine and render it as a curve.
+
+    Returns ``(curve_obj, length, error_message)``. ``curve_obj`` is None
+    when the query couldn't be served; ``error_message`` describes why.
+    """
+    engine = _engines.get(int(level_id))
+    if engine is None:
+        return None, 0.0, f"No routing engine for level {level_id}"
+
+    if not engine.is_routable(from_xy):
+        return None, 0.0, f"From point {from_xy} is not in the walkable area"
+    if not engine.is_routable(to_xy):
+        return None, 0.0, f"To point {to_xy} is not in the walkable area"
+
+    try:
+        waypoints = engine.compute_waypoints(from_xy, to_xy)
+    except Exception as exc:  # noqa: BLE001
+        return None, 0.0, f"compute_waypoints failed: {exc}"
+
+    if len(waypoints) < 2:
+        return None, 0.0, "Router returned an empty path"
+
+    length = 0.0
+    for a, b in zip(waypoints[:-1], waypoints[1:], strict=True):
+        length += math.hypot(a[0] - b[0], a[1] - b[1])
+
+    name = _next_route_name(collection, level_id)
+    curve_data = bpy.data.curves.new(name=name, type="CURVE")
+    curve_data.dimensions = "3D"
+    curve_data.resolution_u = 2
+    spline = curve_data.splines.new("POLY")
+    spline.points.add(len(waypoints) - 1)
+    route_z = z + _ROUTE_Z_OFFSET
+    for i, pt in enumerate(waypoints):
+        spline.points[i].co = (float(pt[0]), float(pt[1]), route_z, 1.0)
+    spline.use_cyclic_u = False
+    curve_data.bevel_depth = 0.05
+    curve_data.bevel_resolution = 2
+
+    material = get_or_create_material(mat_cache, "JuPedSim_Route_Material", (1.0, 0.05, 0.05, 1.0))
+    curve_obj = bpy.data.objects.new(name, curve_data)
+    assign_material(curve_obj, material)
+    collection.objects.link(curve_obj)
+
+    _add_route_endpoint(name + "_From", from_xy, route_z, collection, material)
+    _add_route_endpoint(name + "_To", to_xy, route_z, collection, material)
+
+    return curve_obj, length, None
+
+
+def _next_route_name(collection, level_id):
+    """Avoid clobbering prior routes — they're cheap and useful side-by-side."""
+    n = 0
+    prefix = f"Route_L{level_id}_"
+    for obj in collection.objects:
+        if obj.name.startswith(prefix):
+            n += 1
+    return f"{prefix}{n}"
+
+
+def _add_route_endpoint(name, xy, z, collection, material):
+    mesh = bpy.data.meshes.new(f"{name}_Mesh")
+    bm = bmesh.new()
+    bmesh.ops.create_uvsphere(bm, u_segments=12, v_segments=8, radius=0.15)
+    bm.to_mesh(mesh)
+    bm.free()
+    obj = bpy.data.objects.new(name, mesh)
+    obj.location = (float(xy[0]), float(xy[1]), float(z))
+    assign_material(obj, material)
+    collection.objects.link(obj)
+
+
+def clear_routes(collection: bpy.types.Collection) -> int:
+    """Remove all ``Route_*`` objects from a collection. Returns count."""
+    n = 0
+    for obj in list(collection.objects):
+        if obj.name.startswith("Route_L"):
+            bpy.data.objects.remove(obj, do_unlink=True)
+            n += 1
+    return n
+
+
+def normalize_levels_arg(geometry_or_levels) -> list[dict]:
+    """Coerce single-floor or multi-floor inputs into ``list[NavLevel]``.
+
+    Mirrors the legacy/v3 split in :mod:`blender_jps.core.geometry`:
+    accepts either a list of ``{"id", "z", "polygon"}`` dicts (v3 path)
+    or a single shapely geometry (legacy single-floor path).
+    """
+    if isinstance(geometry_or_levels, list):
+        if not geometry_or_levels:
+            return []
+        if isinstance(geometry_or_levels[0], dict) and "polygon" in geometry_or_levels[0]:
+            return geometry_or_levels
+    polygon = getattr(geometry_or_levels, "polygon", geometry_or_levels)
+    return [{"id": 0, "z": 0.0, "polygon": polygon}]

--- a/blender_jps/install_utils.py
+++ b/blender_jps/install_utils.py
@@ -49,7 +49,7 @@ def install_dependencies(addon_dir, timeout=300):
                 "--upgrade",
                 "--no-user",
                 "pedpy",
-                "jupedsim",
+                "jupedsim<2.0",
                 "numpy<2.0",
             ],
             timeout=timeout,

--- a/blender_jps/install_utils.py
+++ b/blender_jps/install_utils.py
@@ -49,6 +49,7 @@ def install_dependencies(addon_dir, timeout=300):
                 "--upgrade",
                 "--no-user",
                 "pedpy",
+                "jupedsim",
                 "numpy<2.0",
             ],
             timeout=timeout,
@@ -75,6 +76,17 @@ def is_pedpy_installed(addon_dir):
 
     ensure_deps_in_path(addon_dir)
     return importlib.util.find_spec("pedpy") is not None
+
+
+def is_jupedsim_installed(addon_dir):
+    """Check if jupedsim is installed and importable.
+
+    Optional: required only for the navmesh / router debug feature.
+    """
+    import importlib.util
+
+    ensure_deps_in_path(addon_dir)
+    return importlib.util.find_spec("jupedsim") is not None
 
 
 def dependencies_installed(addon_dir):

--- a/blender_jps/operators.py
+++ b/blender_jps/operators.py
@@ -192,7 +192,13 @@ class JUPEDSIM_OT_load_simulation(Operator):
         if self._stage == "create_geometry":
             assert self._worker_data is not None
             self._timed_start("create_geometry")
-            geometry_arg = self._worker_data.get("levels") or self._worker_data["geometry"]
+            # Explicit None-check: an empty levels list (legitimate v3
+            # "no floors" case) is different from the legacy single-
+            # floor geometry path. Don't let a truthy-or-fallback hide it.
+            if self._worker_data.get("levels") is not None:
+                geometry_arg = self._worker_data["levels"]
+            else:
+                geometry_arg = self._worker_data["geometry"]
             num_curves = geo.create_geometry(
                 context,
                 self._worker_data["geometry"],
@@ -213,6 +219,8 @@ class JUPEDSIM_OT_load_simulation(Operator):
             self._timed_end("build_navmesh")
             if engines:
                 self.report({"INFO"}, f"Built routing engines for {len(engines)} level(s)")
+            elif not install_utils.is_jupedsim_installed(ADDON_DIR):
+                self.report({"INFO"}, "jupedsim not installed — navmesh / route picker disabled")
             self._stage = "create_big_data" if self._big_data_mode else "create_agents"
 
         if self._stage == "create_agents":
@@ -610,21 +618,27 @@ class JUPEDSIM_OT_pick_route(Operator):
 
 
 def _switch_to_top_view(context: Context) -> None:
-    """Set every 3D viewport to top-orthographic and frame the geometry.
+    """Set the *active* 3D viewport to top-orthographic and frame it.
 
     Matches jupedsim_visualizer's default — when you load a trajectory
     you almost always want the floor plan, not the user's prior camera.
+    Only touches the area the load was invoked from so multi-viewport
+    workspaces (e.g. perspective camera + floor plan) survive intact.
     """
-    for window in context.window_manager.windows:
-        for area in window.screen.areas:
-            if area.type != "VIEW_3D":
-                continue
-            region = next((r for r in area.regions if r.type == "WINDOW"), None)
-            if region is None:
-                continue
-            with context.temp_override(window=window, area=area, region=region):
-                bpy.ops.view3d.view_axis(type="TOP")
-                bpy.ops.view3d.view_all()
+    area = context.area
+    if area is None or area.type != "VIEW_3D":
+        area = next(
+            (a for a in context.screen.areas if a.type == "VIEW_3D"),
+            None,
+        )
+    if area is None:
+        return
+    region = next((r for r in area.regions if r.type == "WINDOW"), None)
+    if region is None:
+        return
+    with context.temp_override(window=context.window, area=area, region=region):
+        bpy.ops.view3d.view_axis(type="TOP")
+        bpy.ops.view3d.view_all()
 
 
 def _get_or_link_collection(context: Context, name: str) -> bpy.types.Collection:
@@ -643,15 +657,13 @@ def _get_or_link_collection(context: Context, name: str) -> bpy.types.Collection
 
 
 def _level_z_lookup(level_id: int) -> float:
-    """Read level z from the geometry slab object if present, else 0.0."""
-    obj = bpy.data.objects.get(f"JuPedSim_Level_{level_id}")
-    if obj is not None:
-        return float(obj.location.z + obj.bound_box[0][2])
-    # Single-floor (legacy) ground plane
-    obj = bpy.data.objects.get("JuPedSim_Ground_Plane")
-    if obj is not None:
-        return float(obj.location.z)
-    return 0.0
+    """Return the z the navmesh was built at for ``level_id``.
+
+    Reading from the engine cache (rather than re-deriving from slab
+    object locations) keeps the picking plane and the navmesh wireframe
+    aligned even if someone moves a slab object after load.
+    """
+    return nav.level_z(level_id)
 
 
 classes = [

--- a/blender_jps/operators.py
+++ b/blender_jps/operators.py
@@ -314,6 +314,10 @@ class JUPEDSIM_OT_load_simulation(Operator):
         self._materials = {}
         clear_stream_state()
         nav.clear_engines()
+        # Stale routes from a prior load reference coords that may no
+        # longer match the new geometry.
+        if nav.ROUTE_COLLECTION in bpy.data.collections:
+            nav.clear_routes(bpy.data.collections[nav.ROUTE_COLLECTION])
 
     def _finish_success(self, context: Context) -> set[str]:
         """Finalize a successful load."""
@@ -490,6 +494,7 @@ class JUPEDSIM_OT_pick_route(Operator):
     _level_id: int = 0
     _z: float = 0.0
     _from_xy: tuple[float, float] | None = None
+    _from_routable: bool = False
     _last_length: float | None = None
     _collection: bpy.types.Collection | None = None
     _materials: dict | None = None
@@ -509,6 +514,7 @@ class JUPEDSIM_OT_pick_route(Operator):
         self._level_id = level_id
         self._z = _level_z_lookup(level_id)
         self._from_xy = None
+        self._from_routable = False
         self._last_length = None
         self._materials = {}
         self._collection = _get_or_link_collection(context, nav.ROUTE_COLLECTION)
@@ -523,19 +529,36 @@ class JUPEDSIM_OT_pick_route(Operator):
         if event.type in {"ESC", "RIGHTMOUSE"} and event.value == "PRESS":
             return self._end(context, cancel=True)
 
+        # Only act on mouse events that originated in a 3D viewport.
+        # Without this guard, an LMB press in the outliner / properties
+        # panel would feed a non-VIEW_3D RegionView3D into the screen-to-
+        # world projection and yield a junk pick.
+        in_view3d = context.area is not None and context.area.type == "VIEW_3D"
+
         if event.type == "LEFTMOUSE" and event.value == "PRESS":
+            if not in_view3d:
+                return {"PASS_THROUGH"}
             xy = self._screen_to_world(context, event)
             if xy is None:
                 return {"RUNNING_MODAL"}
             self._from_xy = xy
+            self._from_routable = nav.is_routable(self._level_id, xy)
             return {"RUNNING_MODAL"}
 
         if event.type == "MOUSEMOVE" and self._from_xy is not None:
+            if not in_view3d:
+                return {"PASS_THROUGH"}
             xy = self._screen_to_world(context, event)
             if xy is None:
                 return {"RUNNING_MODAL"}
             length, err = nav.update_live_route(
-                self._level_id, self._from_xy, xy, self._z, self._collection, self._materials
+                self._level_id,
+                self._from_xy,
+                xy,
+                self._z,
+                self._collection,
+                self._materials,
+                from_routable=self._from_routable,
             )
             self._last_length = length
             msg = (
@@ -547,6 +570,8 @@ class JUPEDSIM_OT_pick_route(Operator):
             return {"RUNNING_MODAL"}
 
         if event.type == "LEFTMOUSE" and event.value == "RELEASE":
+            if not in_view3d:
+                return {"PASS_THROUGH"}
             return self._end(context, cancel=False)
 
         return {"PASS_THROUGH"}

--- a/blender_jps/operators.py
+++ b/blender_jps/operators.py
@@ -547,8 +547,7 @@ class JUPEDSIM_OT_pick_route(Operator):
             return {"RUNNING_MODAL"}
 
         if event.type == "LEFTMOUSE" and event.value == "RELEASE":
-            self._from_xy = None
-            return {"RUNNING_MODAL"}
+            return self._end(context, cancel=False)
 
         return {"PASS_THROUGH"}
 
@@ -557,6 +556,8 @@ class JUPEDSIM_OT_pick_route(Operator):
         if cancel:
             nav.remove_live_route()
             return {"CANCELLED"}
+        if self._collection is not None:
+            nav.commit_live_route(self._level_id, self._collection)
         return {"FINISHED"}
 
     def _screen_to_world(self, context: Context, event: bpy.types.Event):

--- a/blender_jps/operators.py
+++ b/blender_jps/operators.py
@@ -277,6 +277,7 @@ class JUPEDSIM_OT_load_simulation(Operator):
                     frame_data=self._worker_data.get("frame_data"),
                 )
             context.scene.frame_set(context.scene.frame_start)
+            _switch_to_top_view(context)
             self._timed_end("finalize")
             props.loading_progress = 100.0
             props.loading_message = "Load complete"
@@ -606,6 +607,24 @@ class JUPEDSIM_OT_pick_route(Operator):
         if hit is None:
             return None
         return (float(hit.x), float(hit.y))
+
+
+def _switch_to_top_view(context: Context) -> None:
+    """Set every 3D viewport to top-orthographic and frame the geometry.
+
+    Matches jupedsim_visualizer's default — when you load a trajectory
+    you almost always want the floor plan, not the user's prior camera.
+    """
+    for window in context.window_manager.windows:
+        for area in window.screen.areas:
+            if area.type != "VIEW_3D":
+                continue
+            region = next((r for r in area.regions if r.type == "WINDOW"), None)
+            if region is None:
+                continue
+            with context.temp_override(window=window, area=area, region=region):
+                bpy.ops.view3d.view_axis(type="TOP")
+                bpy.ops.view3d.view_all()
 
 
 def _get_or_link_collection(context: Context, name: str) -> bpy.types.Collection:

--- a/blender_jps/operators.py
+++ b/blender_jps/operators.py
@@ -560,6 +560,114 @@ class JUPEDSIM_OT_route_endpoint_from_cursor(Operator):
         return {"FINISHED"}
 
 
+class JUPEDSIM_OT_pick_route(Operator):
+    """Click-and-drag in the viewport to interactively query the router."""
+
+    bl_idname = "jupedsim.pick_route"
+    bl_label = "Pick Route"
+    bl_description = (
+        "Press to start, then LMB-drag in the viewport to query the routing engine "
+        "live. Release to finalize, ESC/RMB to cancel."
+    )
+
+    _level_id: int = 0
+    _z: float = 0.0
+    _from_xy: tuple[float, float] | None = None
+    _last_length: float | None = None
+    _collection: bpy.types.Collection | None = None
+    _materials: dict | None = None
+
+    @classmethod
+    def poll(cls, context):
+        return context.area is not None and context.area.type == "VIEW_3D"
+
+    def invoke(self, context: Context, event: bpy.types.Event) -> set[str]:
+        if not nav.available_levels():
+            self.report({"ERROR"}, "No routing engines built. Load a simulation first.")
+            return {"CANCELLED"}
+        props = context.scene.jupedsim_props
+        level_id = int(props.route_level)
+        if level_id not in nav.available_levels():
+            level_id = nav.available_levels()[0]
+        self._level_id = level_id
+        self._z = _level_z_lookup(level_id)
+        self._from_xy = None
+        self._last_length = None
+        self._materials = {}
+        if nav.ROUTE_COLLECTION in bpy.data.collections:
+            self._collection = bpy.data.collections[nav.ROUTE_COLLECTION]
+        else:
+            self._collection = geo.get_or_create_collection(nav.ROUTE_COLLECTION)
+        nav.remove_live_route()
+        context.workspace.status_text_set(
+            "Route picker: LMB to set From, drag to query, release to finalize, ESC/RMB to cancel"
+        )
+        context.window_manager.modal_handler_add(self)
+        return {"RUNNING_MODAL"}
+
+    def modal(self, context: Context, event: bpy.types.Event) -> set[str]:
+        if event.type in {"ESC", "RIGHTMOUSE"} and event.value == "PRESS":
+            return self._end(context, cancel=True)
+
+        if event.type == "LEFTMOUSE" and event.value == "PRESS":
+            xy = self._screen_to_world(context, event)
+            if xy is None:
+                return {"RUNNING_MODAL"}
+            self._from_xy = xy
+            return {"RUNNING_MODAL"}
+
+        if event.type == "MOUSEMOVE" and self._from_xy is not None:
+            xy = self._screen_to_world(context, event)
+            if xy is None:
+                return {"RUNNING_MODAL"}
+            length, err = nav.update_live_route(
+                self._level_id, self._from_xy, xy, self._z, self._collection, self._materials
+            )
+            self._last_length = length
+            msg = (
+                f"Route length: {length:.2f} m" if length is not None else "(out of walkable area)"
+            )
+            if err:
+                msg = err
+            context.workspace.status_text_set(f"Route picker — {msg}")
+            return {"RUNNING_MODAL"}
+
+        if event.type == "LEFTMOUSE" and event.value == "RELEASE":
+            self._from_xy = None
+            return {"RUNNING_MODAL"}
+
+        return {"PASS_THROUGH"}
+
+    def _end(self, context: Context, cancel: bool) -> set[str]:
+        context.workspace.status_text_set(None)
+        if cancel:
+            nav.remove_live_route()
+            return {"CANCELLED"}
+        return {"FINISHED"}
+
+    def _screen_to_world(self, context: Context, event: bpy.types.Event):
+        from bpy_extras import view3d_utils
+        from mathutils import Vector
+        from mathutils.geometry import intersect_line_plane
+
+        region = context.region
+        rv3d = context.region_data
+        if region is None or rv3d is None:
+            return None
+        coord = (event.mouse_region_x, event.mouse_region_y)
+        origin = view3d_utils.region_2d_to_origin_3d(region, rv3d, coord)
+        direction = view3d_utils.region_2d_to_vector_3d(region, rv3d, coord)
+        hit = intersect_line_plane(
+            origin,
+            origin + direction * 10000.0,
+            Vector((0.0, 0.0, self._z)),
+            Vector((0.0, 0.0, 1.0)),
+        )
+        if hit is None:
+            return None
+        return (float(hit.x), float(hit.y))
+
+
 def _level_z_lookup(level_id: int) -> float:
     """Read level z from the geometry slab object if present, else 0.0."""
     obj = bpy.data.objects.get(f"JuPedSim_Level_{level_id}")
@@ -580,6 +688,7 @@ classes = [
     JUPEDSIM_OT_compute_route,
     JUPEDSIM_OT_clear_routes,
     JUPEDSIM_OT_route_endpoint_from_cursor,
+    JUPEDSIM_OT_pick_route,
 ]
 
 

--- a/blender_jps/operators.py
+++ b/blender_jps/operators.py
@@ -206,6 +206,10 @@ class JUPEDSIM_OT_load_simulation(Operator):
             self._timed_start("build_navmesh")
             nav_levels = nav.normalize_levels_arg(geometry_arg)
             engines = nav.build_routing_engines(nav_levels)
+            if engines:
+                navmesh_collection = _get_or_link_collection(context, nav.NAVMESH_COLLECTION)
+                nav.clear_navmesh_objects(navmesh_collection)
+                nav.create_navmesh_objects(nav_levels, navmesh_collection, self._materials)
             self._timed_end("build_navmesh")
             if engines:
                 self.report({"INFO"}, f"Built routing engines for {len(engines)} level(s)")
@@ -457,73 +461,6 @@ class JUPEDSIM_OT_load_simulation(Operator):
             print(trace)
 
 
-class JUPEDSIM_OT_show_navmesh(Operator):
-    """Build and show the routing-engine triangulation as wireframe meshes."""
-
-    bl_idname = "jupedsim.show_navmesh"
-    bl_label = "Show Navmesh"
-    bl_description = "Render the jupedsim router's triangulation per level"
-
-    def execute(self, context: Context) -> set[str]:
-        if not nav.available_levels():
-            self.report({"ERROR"}, "No routing engines built. Load a simulation first.")
-            return {"CANCELLED"}
-        collection = _get_or_link_collection(context, nav.NAVMESH_COLLECTION)
-        # Replace any prior navmesh objects so re-clicking Show doesn't pile up.
-        nav.clear_navmesh_objects(collection)
-        nav_levels = [
-            {"id": lvl_id, "z": _level_z_lookup(lvl_id), "polygon": None}
-            for lvl_id in nav.available_levels()
-        ]
-        mat_cache: dict = {}
-        n = nav.create_navmesh_objects(nav_levels, collection, mat_cache)
-        self.report({"INFO"}, f"Built navmesh for {n} level(s)")
-        return {"FINISHED"}
-
-
-class JUPEDSIM_OT_hide_navmesh(Operator):
-    """Remove the navmesh debug objects."""
-
-    bl_idname = "jupedsim.hide_navmesh"
-    bl_label = "Hide Navmesh"
-    bl_description = "Remove the navmesh wireframe collection"
-
-    def execute(self, context: Context) -> set[str]:
-        if nav.NAVMESH_COLLECTION not in bpy.data.collections:
-            return {"FINISHED"}
-        n = nav.clear_navmesh_objects(bpy.data.collections[nav.NAVMESH_COLLECTION])
-        self.report({"INFO"}, f"Removed {n} navmesh object(s)")
-        return {"FINISHED"}
-
-
-class JUPEDSIM_OT_compute_route(Operator):
-    """Run jupedsim's router on (from, to) and draw the result."""
-
-    bl_idname = "jupedsim.compute_route"
-    bl_label = "Compute Route"
-    bl_description = "Query jupedsim's RoutingEngine and draw the waypoints"
-
-    def execute(self, context: Context) -> set[str]:
-        props = context.scene.jupedsim_props
-        if not nav.available_levels():
-            self.report({"ERROR"}, "No routing engines built. Load a simulation first.")
-            return {"CANCELLED"}
-        level_id = int(props.route_level)
-        if level_id not in nav.available_levels():
-            level_id = nav.available_levels()[0]
-        from_xy = (float(props.route_from[0]), float(props.route_from[1]))
-        to_xy = (float(props.route_to[0]), float(props.route_to[1]))
-        collection = _get_or_link_collection(context, nav.ROUTE_COLLECTION)
-        mat_cache: dict = {}
-        z = _level_z_lookup(level_id)
-        _, length, err = nav.compute_route_curve(level_id, from_xy, to_xy, z, collection, mat_cache)
-        if err:
-            self.report({"ERROR"}, err)
-            return {"CANCELLED"}
-        self.report({"INFO"}, f"Route length: {length:.2f} m")
-        return {"FINISHED"}
-
-
 class JUPEDSIM_OT_clear_routes(Operator):
     """Remove all previously computed route curves."""
 
@@ -537,25 +474,6 @@ class JUPEDSIM_OT_clear_routes(Operator):
         collection = bpy.data.collections[nav.ROUTE_COLLECTION]
         n = nav.clear_routes(collection)
         self.report({"INFO"}, f"Cleared {n} route object(s)")
-        return {"FINISHED"}
-
-
-class JUPEDSIM_OT_route_endpoint_from_cursor(Operator):
-    """Copy the 3D cursor's XY into the route From or To property."""
-
-    bl_idname = "jupedsim.route_endpoint_from_cursor"
-    bl_label = "Use 3D Cursor"
-    bl_description = "Set the route endpoint from the 3D cursor's XY position"
-
-    target: StringProperty(default="from")  # "from" or "to"
-
-    def execute(self, context: Context) -> set[str]:
-        cursor = context.scene.cursor.location
-        props = context.scene.jupedsim_props
-        if self.target == "to":
-            props.route_to = (cursor.x, cursor.y)
-        else:
-            props.route_from = (cursor.x, cursor.y)
         return {"FINISHED"}
 
 
@@ -694,11 +612,7 @@ def _level_z_lookup(level_id: int) -> float:
 classes = [
     JUPEDSIM_OT_select_file,
     JUPEDSIM_OT_load_simulation,
-    JUPEDSIM_OT_show_navmesh,
-    JUPEDSIM_OT_hide_navmesh,
-    JUPEDSIM_OT_compute_route,
     JUPEDSIM_OT_clear_routes,
-    JUPEDSIM_OT_route_endpoint_from_cursor,
     JUPEDSIM_OT_pick_route,
 ]
 

--- a/blender_jps/operators.py
+++ b/blender_jps/operators.py
@@ -18,6 +18,7 @@ from bpy_extras.io_utils import ImportHelper
 
 from . import install_utils
 from .core import geometry as geo
+from .core import navmesh as nav
 from .core.streaming import clear_stream_state, start_streaming
 from .io.hdf5_reader import read_simulation_data as read_hdf5_data
 from .io.sqlite_reader import read_simulation_data as read_sqlite_data
@@ -191,6 +192,7 @@ class JUPEDSIM_OT_load_simulation(Operator):
         if self._stage == "create_geometry":
             assert self._worker_data is not None
             self._timed_start("create_geometry")
+            geometry_arg = self._worker_data.get("levels") or self._worker_data["geometry"]
             num_curves = geo.create_geometry(
                 context,
                 self._worker_data["geometry"],
@@ -201,6 +203,12 @@ class JUPEDSIM_OT_load_simulation(Operator):
             self.report({"INFO"}, f"Created geometry with {num_curves} boundary curves")
             props.loading_message = "Creating geometry..."
             props.loading_progress = 25.0
+            self._timed_start("build_navmesh")
+            nav_levels = nav.normalize_levels_arg(geometry_arg)
+            engines = nav.build_routing_engines(nav_levels)
+            self._timed_end("build_navmesh")
+            if engines:
+                self.report({"INFO"}, f"Built routing engines for {len(engines)} level(s)")
             self._stage = "create_big_data" if self._big_data_mode else "create_agents"
 
         if self._stage == "create_agents":
@@ -301,6 +309,7 @@ class JUPEDSIM_OT_load_simulation(Operator):
         self._path_groups = None
         self._materials = {}
         clear_stream_state()
+        nav.clear_engines()
 
     def _finish_success(self, context: Context) -> set[str]:
         """Finalize a successful load."""
@@ -448,9 +457,129 @@ class JUPEDSIM_OT_load_simulation(Operator):
             print(trace)
 
 
+class JUPEDSIM_OT_show_navmesh(Operator):
+    """Build and show the routing-engine triangulation as wireframe meshes."""
+
+    bl_idname = "jupedsim.show_navmesh"
+    bl_label = "Show Navmesh"
+    bl_description = "Render the jupedsim router's triangulation per level"
+
+    def execute(self, context: Context) -> set[str]:
+        if not nav.available_levels():
+            self.report({"ERROR"}, "No routing engines built. Load a simulation first.")
+            return {"CANCELLED"}
+        collection = geo.get_or_create_collection(nav.NAVMESH_COLLECTION)
+        # Reuse the geometry's level z lookup if levels were loaded.
+        nav_levels = [
+            {"id": lvl_id, "z": _level_z_lookup(lvl_id), "polygon": None}
+            for lvl_id in nav.available_levels()
+        ]
+        mat_cache: dict = {}
+        n = nav.create_navmesh_objects(nav_levels, collection, mat_cache)
+        self.report({"INFO"}, f"Built navmesh for {n} level(s)")
+        return {"FINISHED"}
+
+
+class JUPEDSIM_OT_hide_navmesh(Operator):
+    """Remove the navmesh debug objects."""
+
+    bl_idname = "jupedsim.hide_navmesh"
+    bl_label = "Hide Navmesh"
+    bl_description = "Remove the navmesh wireframe collection"
+
+    def execute(self, context: Context) -> set[str]:
+        if nav.NAVMESH_COLLECTION in bpy.data.collections:
+            geo.get_or_create_collection(nav.NAVMESH_COLLECTION)  # clears contents
+        return {"FINISHED"}
+
+
+class JUPEDSIM_OT_compute_route(Operator):
+    """Run jupedsim's router on (from, to) and draw the result."""
+
+    bl_idname = "jupedsim.compute_route"
+    bl_label = "Compute Route"
+    bl_description = "Query jupedsim's RoutingEngine and draw the waypoints"
+
+    def execute(self, context: Context) -> set[str]:
+        props = context.scene.jupedsim_props
+        if not nav.available_levels():
+            self.report({"ERROR"}, "No routing engines built. Load a simulation first.")
+            return {"CANCELLED"}
+        level_id = int(props.route_level)
+        if level_id not in nav.available_levels():
+            level_id = nav.available_levels()[0]
+        from_xy = (float(props.route_from[0]), float(props.route_from[1]))
+        to_xy = (float(props.route_to[0]), float(props.route_to[1]))
+        collection = (
+            geo.get_or_create_collection(nav.ROUTE_COLLECTION)
+            if nav.ROUTE_COLLECTION not in bpy.data.collections
+            else bpy.data.collections[nav.ROUTE_COLLECTION]
+        )
+        mat_cache: dict = {}
+        z = _level_z_lookup(level_id)
+        _, length, err = nav.compute_route_curve(level_id, from_xy, to_xy, z, collection, mat_cache)
+        if err:
+            self.report({"ERROR"}, err)
+            return {"CANCELLED"}
+        self.report({"INFO"}, f"Route length: {length:.2f} m")
+        return {"FINISHED"}
+
+
+class JUPEDSIM_OT_clear_routes(Operator):
+    """Remove all previously computed route curves."""
+
+    bl_idname = "jupedsim.clear_routes"
+    bl_label = "Clear Routes"
+    bl_description = "Remove all Route_* objects"
+
+    def execute(self, context: Context) -> set[str]:
+        if nav.ROUTE_COLLECTION not in bpy.data.collections:
+            return {"FINISHED"}
+        collection = bpy.data.collections[nav.ROUTE_COLLECTION]
+        n = nav.clear_routes(collection)
+        self.report({"INFO"}, f"Cleared {n} route object(s)")
+        return {"FINISHED"}
+
+
+class JUPEDSIM_OT_route_endpoint_from_cursor(Operator):
+    """Copy the 3D cursor's XY into the route From or To property."""
+
+    bl_idname = "jupedsim.route_endpoint_from_cursor"
+    bl_label = "Use 3D Cursor"
+    bl_description = "Set the route endpoint from the 3D cursor's XY position"
+
+    target: StringProperty(default="from")  # "from" or "to"
+
+    def execute(self, context: Context) -> set[str]:
+        cursor = context.scene.cursor.location
+        props = context.scene.jupedsim_props
+        if self.target == "to":
+            props.route_to = (cursor.x, cursor.y)
+        else:
+            props.route_from = (cursor.x, cursor.y)
+        return {"FINISHED"}
+
+
+def _level_z_lookup(level_id: int) -> float:
+    """Read level z from the geometry slab object if present, else 0.0."""
+    obj = bpy.data.objects.get(f"JuPedSim_Level_{level_id}")
+    if obj is not None:
+        return float(obj.location.z + obj.bound_box[0][2])
+    # Single-floor (legacy) ground plane
+    obj = bpy.data.objects.get("JuPedSim_Ground_Plane")
+    if obj is not None:
+        return float(obj.location.z)
+    return 0.0
+
+
 classes = [
     JUPEDSIM_OT_select_file,
     JUPEDSIM_OT_load_simulation,
+    JUPEDSIM_OT_show_navmesh,
+    JUPEDSIM_OT_hide_navmesh,
+    JUPEDSIM_OT_compute_route,
+    JUPEDSIM_OT_clear_routes,
+    JUPEDSIM_OT_route_endpoint_from_cursor,
 ]
 
 

--- a/blender_jps/operators.py
+++ b/blender_jps/operators.py
@@ -468,8 +468,9 @@ class JUPEDSIM_OT_show_navmesh(Operator):
         if not nav.available_levels():
             self.report({"ERROR"}, "No routing engines built. Load a simulation first.")
             return {"CANCELLED"}
-        collection = geo.get_or_create_collection(nav.NAVMESH_COLLECTION)
-        # Reuse the geometry's level z lookup if levels were loaded.
+        collection = _get_or_link_collection(context, nav.NAVMESH_COLLECTION)
+        # Replace any prior navmesh objects so re-clicking Show doesn't pile up.
+        nav.clear_navmesh_objects(collection)
         nav_levels = [
             {"id": lvl_id, "z": _level_z_lookup(lvl_id), "polygon": None}
             for lvl_id in nav.available_levels()
@@ -488,8 +489,10 @@ class JUPEDSIM_OT_hide_navmesh(Operator):
     bl_description = "Remove the navmesh wireframe collection"
 
     def execute(self, context: Context) -> set[str]:
-        if nav.NAVMESH_COLLECTION in bpy.data.collections:
-            geo.get_or_create_collection(nav.NAVMESH_COLLECTION)  # clears contents
+        if nav.NAVMESH_COLLECTION not in bpy.data.collections:
+            return {"FINISHED"}
+        n = nav.clear_navmesh_objects(bpy.data.collections[nav.NAVMESH_COLLECTION])
+        self.report({"INFO"}, f"Removed {n} navmesh object(s)")
         return {"FINISHED"}
 
 
@@ -510,11 +513,7 @@ class JUPEDSIM_OT_compute_route(Operator):
             level_id = nav.available_levels()[0]
         from_xy = (float(props.route_from[0]), float(props.route_from[1]))
         to_xy = (float(props.route_to[0]), float(props.route_to[1]))
-        collection = (
-            geo.get_or_create_collection(nav.ROUTE_COLLECTION)
-            if nav.ROUTE_COLLECTION not in bpy.data.collections
-            else bpy.data.collections[nav.ROUTE_COLLECTION]
-        )
+        collection = _get_or_link_collection(context, nav.ROUTE_COLLECTION)
         mat_cache: dict = {}
         z = _level_z_lookup(level_id)
         _, length, err = nav.compute_route_curve(level_id, from_xy, to_xy, z, collection, mat_cache)
@@ -594,10 +593,7 @@ class JUPEDSIM_OT_pick_route(Operator):
         self._from_xy = None
         self._last_length = None
         self._materials = {}
-        if nav.ROUTE_COLLECTION in bpy.data.collections:
-            self._collection = bpy.data.collections[nav.ROUTE_COLLECTION]
-        else:
-            self._collection = geo.get_or_create_collection(nav.ROUTE_COLLECTION)
+        self._collection = _get_or_link_collection(context, nav.ROUTE_COLLECTION)
         nav.remove_live_route()
         context.workspace.status_text_set(
             "Route picker: LMB to set From, drag to query, release to finalize, ESC/RMB to cancel"
@@ -666,6 +662,21 @@ class JUPEDSIM_OT_pick_route(Operator):
         if hit is None:
             return None
         return (float(hit.x), float(hit.y))
+
+
+def _get_or_link_collection(context: Context, name: str) -> bpy.types.Collection:
+    """Return an existing collection (don't clear it) or link a new one.
+
+    Unlike :func:`geometry.get_or_create_collection`, this preserves the
+    contents — important when the navmesh/routes share the same
+    collection as the floor slabs and obstacles.
+    """
+    coll = bpy.data.collections.get(name)
+    if coll is not None:
+        return coll
+    coll = bpy.data.collections.new(name)
+    context.scene.collection.children.link(coll)
+    return coll
 
 
 def _level_z_lookup(level_id: int) -> float:

--- a/blender_jps/panels.py
+++ b/blender_jps/panels.py
@@ -183,6 +183,13 @@ class JUPEDSIM_PT_navmesh_panel(Panel):
         box.label(text="Router Query", icon="DRIVER_DISTANCE")
         if len(levels) > 1:
             box.prop(props, "route_level", text="Level")
+        row = box.row()
+        row.scale_y = 1.3
+        row.operator(
+            "jupedsim.pick_route", text="Pick Route (LMB-drag)", icon="RESTRICT_SELECT_OFF"
+        )
+        box.separator()
+        box.label(text="Or enter coordinates:")
         row = box.row(align=True)
         row.prop(props, "route_from", text="From")
         op = row.operator("jupedsim.route_endpoint_from_cursor", text="", icon="CURSOR")

--- a/blender_jps/panels.py
+++ b/blender_jps/panels.py
@@ -8,7 +8,8 @@ import os
 import bpy
 from bpy.types import Context, Panel
 
-from .install_utils import is_pedpy_installed
+from .core import navmesh as nav
+from .install_utils import is_jupedsim_installed, is_pedpy_installed
 
 ADDON_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -145,9 +146,60 @@ class JUPEDSIM_PT_info_panel(Panel):
         box.label(text=f"Frame range: {context.scene.frame_start} - {context.scene.frame_end}")
 
 
+class JUPEDSIM_PT_navmesh_panel(Panel):
+    """Routing-engine debug visualization (triangulation + path queries)."""
+
+    bl_label = "Navigation Debug"
+    bl_idname = "JUPEDSIM_PT_navmesh_panel"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "JuPedSim"
+    bl_options = {"DEFAULT_CLOSED"}
+
+    def draw(self, context: Context) -> None:
+        layout = self.layout
+        props = context.scene.jupedsim_props
+
+        if not is_jupedsim_installed(ADDON_DIR):
+            box = layout.box()
+            box.alert = True
+            box.label(text="jupedsim not installed", icon="ERROR")
+            box.label(text="Re-run 'Install Dependencies' in")
+            box.label(text="addon preferences to enable this.")
+            return
+
+        levels = nav.available_levels()
+        if not levels:
+            layout.label(text="Load a simulation first.", icon="INFO")
+            return
+
+        box = layout.box()
+        box.label(text="Triangulation", icon="MESH_DATA")
+        row = box.row(align=True)
+        row.operator("jupedsim.show_navmesh", text="Show", icon="HIDE_OFF")
+        row.operator("jupedsim.hide_navmesh", text="Hide", icon="HIDE_ON")
+
+        box = layout.box()
+        box.label(text="Router Query", icon="DRIVER_DISTANCE")
+        if len(levels) > 1:
+            box.prop(props, "route_level", text="Level")
+        row = box.row(align=True)
+        row.prop(props, "route_from", text="From")
+        op = row.operator("jupedsim.route_endpoint_from_cursor", text="", icon="CURSOR")
+        op.target = "from"
+        row = box.row(align=True)
+        row.prop(props, "route_to", text="To")
+        op = row.operator("jupedsim.route_endpoint_from_cursor", text="", icon="CURSOR")
+        op.target = "to"
+        row = box.row(align=True)
+        row.operator("jupedsim.compute_route", text="Compute Route", icon="PLAY")
+        row.operator("jupedsim.clear_routes", text="Clear", icon="X")
+
+
 classes = [
     JUPEDSIM_PT_main_panel,
     JUPEDSIM_PT_info_panel,
+    JUPEDSIM_PT_navmesh_panel,
 ]
 
 

--- a/blender_jps/panels.py
+++ b/blender_jps/panels.py
@@ -173,34 +173,14 @@ class JUPEDSIM_PT_navmesh_panel(Panel):
             layout.label(text="Load a simulation first.", icon="INFO")
             return
 
-        box = layout.box()
-        box.label(text="Triangulation", icon="MESH_DATA")
-        row = box.row(align=True)
-        row.operator("jupedsim.show_navmesh", text="Show", icon="HIDE_OFF")
-        row.operator("jupedsim.hide_navmesh", text="Hide", icon="HIDE_ON")
-
-        box = layout.box()
-        box.label(text="Router Query", icon="DRIVER_DISTANCE")
         if len(levels) > 1:
-            box.prop(props, "route_level", text="Level")
-        row = box.row()
+            layout.prop(props, "route_level", text="Level")
+        row = layout.row()
         row.scale_y = 1.3
         row.operator(
             "jupedsim.pick_route", text="Pick Route (LMB-drag)", icon="RESTRICT_SELECT_OFF"
         )
-        box.separator()
-        box.label(text="Or enter coordinates:")
-        row = box.row(align=True)
-        row.prop(props, "route_from", text="From")
-        op = row.operator("jupedsim.route_endpoint_from_cursor", text="", icon="CURSOR")
-        op.target = "from"
-        row = box.row(align=True)
-        row.prop(props, "route_to", text="To")
-        op = row.operator("jupedsim.route_endpoint_from_cursor", text="", icon="CURSOR")
-        op.target = "to"
-        row = box.row(align=True)
-        row.operator("jupedsim.compute_route", text="Compute Route", icon="PLAY")
-        row.operator("jupedsim.clear_routes", text="Clear", icon="X")
+        layout.operator("jupedsim.clear_routes", text="Clear Routes", icon="X")
 
 
 classes = [

--- a/blender_jps/tests/test_navmesh_normalize.py
+++ b/blender_jps/tests/test_navmesh_normalize.py
@@ -1,0 +1,101 @@
+"""Unit test for ``navmesh.normalize_levels_arg``.
+
+Runs under plain CPython (no Blender). The function is pure logic but
+lives in a module that imports ``bpy`` / ``bmesh`` at the top, so we
+stub those in ``sys.modules`` before importing.
+
+This is the seam where v3 multi-floor will plug in — a fast regression
+guard for the single-floor ↔ multi-floor adapter.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+import unittest
+
+
+def _load_normalize_levels_arg():
+    """Load ``normalize_levels_arg`` without dragging the full addon in.
+
+    The function is pure logic, but its module imports ``bpy`` /
+    ``bmesh`` and the package's ``__init__`` runs a lot of Blender
+    setup. We stub the Blender modules, fake out the ``geometry``
+    sibling so the relative import resolves, then load ``navmesh.py``
+    directly from disk.
+    """
+    import importlib.util
+
+    here = os.path.abspath(os.path.dirname(__file__))
+    addon_dir = os.path.abspath(os.path.join(here, ".."))
+
+    for name in ("bpy", "bpy.types", "bpy.props", "bpy.app", "bmesh"):
+        sys.modules.setdefault(name, types.ModuleType(name))
+
+    # Minimal package hierarchy so `from .geometry import ...` resolves
+    # without executing the real package __init__.
+    pkg = types.ModuleType("blender_jps")
+    pkg.__path__ = [addon_dir]
+    sys.modules["blender_jps"] = pkg
+    core = types.ModuleType("blender_jps.core")
+    core.__path__ = [os.path.join(addon_dir, "core")]
+    sys.modules["blender_jps.core"] = core
+    geometry = types.ModuleType("blender_jps.core.geometry")
+    geometry.assign_material = lambda *a, **kw: None
+    geometry.get_or_create_material = lambda *a, **kw: None
+    sys.modules["blender_jps.core.geometry"] = geometry
+
+    spec = importlib.util.spec_from_file_location(
+        "blender_jps.core.navmesh", os.path.join(addon_dir, "core", "navmesh.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["blender_jps.core.navmesh"] = module
+    spec.loader.exec_module(module)
+    return module.normalize_levels_arg
+
+
+class _FakePolygon:
+    """Just enough to look like a shapely polygon to the adapter."""
+
+    is_empty = False
+
+
+class _ObjectWithPolygon:
+    def __init__(self, polygon):
+        self.polygon = polygon
+
+
+class NormalizeLevelsArgTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.normalize = staticmethod(_load_normalize_levels_arg())
+
+    def test_v3_list_of_dicts_passes_through(self):
+        levels = [
+            {"id": 0, "z": 0.0, "polygon": _FakePolygon()},
+            {"id": 1, "z": 3.5, "polygon": _FakePolygon()},
+        ]
+        self.assertIs(self.normalize(levels), levels)
+
+    def test_empty_list_returns_empty(self):
+        self.assertEqual(self.normalize([]), [])
+
+    def test_bare_polygon_wraps_to_single_level(self):
+        polygon = _FakePolygon()
+        result = self.normalize(polygon)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], 0)
+        self.assertEqual(result[0]["z"], 0.0)
+        self.assertIs(result[0]["polygon"], polygon)
+
+    def test_object_with_polygon_attr_is_unwrapped(self):
+        polygon = _FakePolygon()
+        wrapper = _ObjectWithPolygon(polygon)
+        result = self.normalize(wrapper)
+        self.assertEqual(len(result), 1)
+        self.assertIs(result[0]["polygon"], polygon)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
We would like to have this feature in order to replace the jupedsim-visualizer for good.

Optional debug visualization wrapping jupedsim's `RoutingEngine`:

- Per-level **triangulation overlay** rendered as a wireframe mesh in a dedicated `JuPedSim_Navmesh` collection — toggle from the outliner like any other collection.
- **Interactive route picker**: LMB-drag in the 3D viewport queries the router live, streams the path length to the header, and persists a numbered route on release (`Route_Live` → `Route_L0_<n>`).
