### PR TITLE
zipit: exclude kinora/deps.deleted-* from release zip

### DIFF
--- a/zipit.sh
+++ b/zipit.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 zip -r Kinora.zip kinora \
     -x "kinora/deps/*" \
+    -x "kinora/deps.deleted-*/*" \
     -x "kinora/tests/*" \
     -x "kinora/examples/040_l020_g1_rf_h-.h5" \
     -x "kinora/__pycache__/*" \


### PR DESCRIPTION
The Windows uninstall-fallback in `preferences.py` moves the locked deps dir aside as `kinora/deps.deleted-<timestamp>/` when `shutil.rmtree` can't release file handles. `zipit.sh` only excluded `kinora/deps/*`, so the next release build after such a fallback would silently bundle ~80MB of stale pedpy/numpy/scipy binaries into `Kinora.zip`.

Hit during the v0.2.0 release prep — the first `Kinora.zip` build came out at 80MB instead of the expected ~400KB.

Dependencies are installed on the fly in Blender via the addon preferences — nothing dep-related belongs in the release artifact.

One-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)