### PR TITLE
Outline KIN text to paths in logo SVGs

### DIFF
--- a/images/kinora-logo-dark.svg
+++ b/images/kinora-logo-dark.svg
@@ -90,14 +90,14 @@
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#505050"
      inkscape:zoom="9.9675676"
-     inkscape:cx="87.584056"
+     inkscape:cx="87.533893"
      inkscape:cy="40.882592"
      inkscape:window-width="3840"
      inkscape:window-height="2054"
      inkscape:window-x="2149"
      inkscape:window-y="943"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g4-8" />
+     inkscape:current-layer="svg8" />
   <style
      id="style1">
     .kn-text       { fill: #1f2328; }
@@ -121,12 +121,12 @@
      cy="33.316208"
      rx="9.0713749"
      ry="10.560706" />
-  <text
-     x="-1.520658"
-     y="41.78249"
+  <path
+     d="M 19.819691,41.78249 H 12.563972 L 8.8333631,33.625734 6.6044822,36.803075 V 41.78249 H 0.36045422 V 20.205026 H 6.6044822 v 8.915523 l 5.9594898,-8.915523 h 5.943683 L 13.05401,28.093051 Z M 32.974461,20.205026 V 41.78249 H 26.351049 V 20.205026 Z M 59.945131,41.78249 H 54.554717 L 48.64265,32.250467 q -1.138152,-1.833689 -2.292112,-4.457762 0.521653,2.086612 0.521653,3.540918 V 41.78249 H 41.497585 V 20.205026 h 6.259836 l 5.026837,7.903833 q 1.501729,2.355342 2.276304,4.141608 -0.505845,-2.766341 -0.505845,-5.659144 v -6.386297 h 5.390414 z"
+     id="text1-4"
+     style="font-size:32.3741px;font-family:'Franklin Gothic Heavy', 'Arial Black', sans-serif;letter-spacing:4.7609px;fill:#ffffff;stroke-width:0.899697"
      class="kn-text"
-     style="font-style:normal;font-weight:normal;font-stretch:normal;font-size:32.3741px;font-family:'Franklin Gothic Heavy', 'Arial Black', sans-serif;letter-spacing:4.7609px;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.899697"
-     id="text1-4">KIN</text>
+     aria-label="KIN" />
   <g
      class="kn-stroke"
      fill="none"

--- a/images/kinora-logo-light.svg
+++ b/images/kinora-logo-light.svg
@@ -50,8 +50,8 @@
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#505050"
      inkscape:zoom="14.096269"
-     inkscape:cx="82.57504"
-     inkscape:cy="38.414419"
+     inkscape:cx="82.539571"
+     inkscape:cy="38.41442"
      inkscape:window-width="3840"
      inkscape:window-height="2054"
      inkscape:window-x="2149"
@@ -78,12 +78,12 @@
      cy="33.566849"
      rx="9.3487673"
      ry="10.883639" />
-  <text
-     x="-1.3783008"
-     y="42.292019"
+  <path
+     d="M 20.614569,42.292019 H 13.136993 L 9.2923139,33.885855 6.9952808,37.160349 v 5.13167 H 0.56032998 V 20.054784 H 6.9952808 v 9.188132 l 6.1417122,-9.188132 h 6.125422 L 13.642015,28.184 Z M 34.171578,20.054784 V 42.292019 H 27.345643 V 20.054784 Z m 27.795355,22.237235 h -5.555236 l -6.092839,-9.823482 q -1.172953,-1.889758 -2.362197,-4.594066 0.537603,2.150414 0.537603,3.649187 V 42.292019 H 42.955319 V 20.054784 h 6.451242 l 5.180543,8.145507 q 1.547646,2.427361 2.345906,4.268246 -0.521313,-2.850928 -0.521313,-5.832183 v -6.58157 h 5.555236 z"
+     id="text1"
+     style="font-size:33.364px;font-family:'Franklin Gothic Heavy', 'Arial Black', sans-serif;letter-spacing:4.90648px;fill:#1f2328;stroke-width:0.927209"
      class="kn-text"
-     style="font-style:normal;font-weight:normal;font-stretch:normal;font-size:33.364px;font-family:'Franklin Gothic Heavy', 'Arial Black', sans-serif;letter-spacing:4.90648px;text-anchor:start;stroke-width:0.927209"
-     id="text1">KIN</text>
+     aria-label="KIN" />
   <!-- Viewport brackets framing the Blender mark (the "lens" of the viewer) -->
   <g
      class="kn-stroke"


### PR DESCRIPTION
## Summary
- KIN was a live `<text>` element using `Franklin Gothic Heavy, Arial Black, sans-serif`. On Android (no Franklin Gothic Heavy, no Arial Black) it fell through to Roboto Regular, rendering noticeably thinner than the outlined RA path next to it.
- Converted KIN to `<path>` in both `images/kinora-logo-light.svg` and `images/kinora-logo-dark.svg` (Inkscape Object → Path), so the logo no longer depends on any installed system font.
- `aria-label="KIN"` preserved on the new path for screen readers; the existing top-level `aria-label="Kinora"` is unchanged.

## Test plan
- [x] View both SVGs in a desktop browser — KIN weight unchanged vs. before.
- [x] View both SVGs on Android Chrome — KIN now matches RA weight (no thin Roboto fallback).
- [x] View both SVGs on iOS Safari — unchanged from before.
- [x] Confirm the README logo still renders correctly at its current display height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)