### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Install
 
 1. Download the latest ZIP from [Releases](https://github.com/FabianPlum/Kinora/releases).
-2. In Blender (4.0 or newer): **Edit > Preferences > Add-ons > Install...** and pick the ZIP.
+2. In [Blender](https://www.blender.org/download/) (4.0 or newer): **Edit > Preferences > Add-ons > Install...** and pick the ZIP.
 3. Tick the box next to **Kinora**.
 4. Expand the addon and click **Install Dependencies** (give it a minute or two).
 5. Restart Blender.

--- a/kinora/__init__.py
+++ b/kinora/__init__.py
@@ -14,7 +14,7 @@ install_utils.ensure_deps_in_path(ADDON_DIR)
 bl_info = {
     "name": "Kinora - Pedestrian Data Visualiser",
     "author": "Fabian Plum & Mohcine Chraibi",
-    "version": (0, 2, 0),
+    "version": (0, 2, 1),
     "blender": (4, 0, 0),
     "location": "View3D > Sidebar > Kinora",
     "description": "Visualise Pedestrian Data trajectory files (SQLite and HDF5) with agent animations and geometry",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Kinora"
-version = "0.2.0"
+version = "0.2.1"
 requires-python = ">=3.11"
 
 


### PR DESCRIPTION
Prepares the **0.2.1** release.

### Changes in this PR
- Bump version to `0.2.1` in both `pyproject.toml` and `kinora/__init__.py` (`bl_info`).
- Link the [Blender download page](https://www.blender.org/download/) from the README install steps.

### What 0.2.1 ships (since 0.2.0)
- 🆕 Cylinder agents (replacing spheres) with full artefact cleanup and a resilient shared mesh
- 🐛 Faster playback — toggle agent visibility only when it changes
- 🔧 Reworked dependency installer — reuse Blender's bundled numpy instead of swapping it at runtime
- 🐛 HDF5: call pedpy archive loaders with the `trajectory_file` keyword
- 🐛 Wipe all Kinora artefacts at the start of each load
- 🧪 CI matrix-tests install across Ubuntu/macOS on Blender 5.0 & 5.1

A draft GitHub release (`0.2.1`) with the built `Kinora_0.2.1.zip` is prepared separately — merge this first so the tag lands on the bumped commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)