### PR TITLE
Fix big-data-mode cylinder orientation + cylinder docs

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -20,7 +20,7 @@ Everything that used to live in the README but isn't strictly necessary for some
 
 - **Import (JuPedSim) SQLite or h5 files**: trajectory data and walkable area geometry.
 - **Import HDF5 files**: trajectory data and walkable area geometry.
-- **Animated agents**: each agent is an animated sphere following its trajectory.
+- **Animated agents**: each agent is an animated cylinder following its trajectory.
 - **Agent path visualisation**: each agent's complete path is created as a curve object.
 - **Path visibility toggle**: show or hide all agent path curves with a single checkbox.
 - **Geometry visualisation**: walkable area boundaries and obstacles are displayed as curves.
@@ -68,7 +68,7 @@ The **Kinora** panel will appear in the right sidebar of the 3D Viewport (press 
 
 ## What gets created
 
-- **Kinora_Agents** collection: contains animated empty objects (sphere display) for each agent.
+- **Kinora_Agents** collection: contains an animated cylinder mesh for each agent.
   - Agents automatically hide after reaching their destination.
   - Path curves for each agent showing their complete trajectory (hidden by default).
 - **Big Data Mode**: creates a single particle system driven by streamed frame updates.
@@ -79,7 +79,7 @@ The **Kinora** panel will appear in the right sidebar of the 3D Viewport (press 
 
 After loading a simulation, a **Display Options** section appears in the panel:
 
-- **Agent Scale (m)**: adjust size of agent spheres or instances.
+- **Agent Scale (m)**: adjust size of agent cylinders or instances.
 - **Geometry Thickness (m)**: adjust thickness of walkable area curves.
 - **Frame Rate**: quick access to Blender frame rate presets.
 - **Show Agent Paths**: toggle checkbox to show or hide all agent path curves.
@@ -115,7 +115,7 @@ The addon uses [PedPy](https://github.com/PedestrianDynamics/PedPy) (mainly for 
 ### Agents appear at wrong scale
 
 - JuPedSim uses meters as units. Make sure your Blender scene is set to metric units.
-- Agents are created as 1-meter diameter empty objects (sphere display) by default.
+- Agents are created as 1-meter cylinders by default.
 
 ### Loading takes too long
 

--- a/kinora/core/geometry.py
+++ b/kinora/core/geometry.py
@@ -338,6 +338,12 @@ def create_big_data_points(context, agent_ids, agents_collection, mat_cache):
     ps_settings.use_emit_random = False
     ps_settings.render_type = "OBJECT"
     ps_settings.instance_object = instance_obj
+    # Keep instances upright. By default the particle system aligns each
+    # instance's local axis to the hair/velocity direction, which lays the
+    # Z-up cylinder on its side; rotation_mode "NONE" preserves the instance's
+    # own orientation instead.
+    ps_settings.use_rotations = True
+    ps_settings.rotation_mode = "NONE"
     ps_settings.particle_size = 0.25
     ps_settings.display_method = "RENDER"
     ps_settings.display_percentage = 100


### PR DESCRIPTION
### Big Data Mode: cylinders were lying on their side

In Big Data Mode agents are rendered as objects instanced on a HAIR particle system. By default Blender aligns each instance's local axis to the hair/velocity direction, which laid the Z-up cylinder on its **side** — the flat caps pointed sideways instead of the cylinder standing upright along Z.

**Fix:** enable particle rotations with `rotation_mode = "NONE"` so instances keep their own (upright) orientation:

```python
ps_settings.use_rotations = True
ps_settings.rotation_mode = "NONE"
```

**Verification (headless, real `create_big_data_points`):** I loaded the actual geometry module and measured the evaluated particle-instance transform across **Blender 4.2, 4.4 and 5.1**. Before the fix the instance's local +Z mapped to world **+X** (on-side); after the fix it maps to world **+Z** (upright) in all three versions. Confirmed visually by @FabianPlum.

### Docs

`DEVELOPER.md` still described agents as spheres / empty objects — updated to cylinders (single-agent path now uses a shared cylinder mesh).

> Scope note: this branch intentionally does **not** touch the in-progress HDF5 "advanced visualisations" work (`hdf5_reader.py`, `__init__.py`) on the working tree — those stay separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)