### PR TITLE
Advanced Visualisations: background-image overlays (static + animated)

### DIFF
--- a/kinora/__init__.py
+++ b/kinora/__init__.py
@@ -75,11 +75,29 @@ def update_geometry_thickness(self, context):
             obj.data.bevel_depth = self.geometry_thickness
 
 
-def update_image_overlay(self, context):
-    """Apply, update, or remove the background overlay when settings change."""
+def update_image_overlay_visibility(self, context):
+    """Show/hide the overlay and sync viewport shading to its visibility.
+
+    Enabling switches Solid/Wireframe viewports to Material Preview so the
+    emission material is actually visible (otherwise it looks like the bitmap
+    failed to load); disabling reverts Material-Preview viewports to Solid.
+    """
     from .core import overlay
 
     overlay.refresh(context)
+    if self.show_image_overlay:
+        overlay.ensure_material_preview(context)
+    else:
+        overlay.restore_solid_shading(context)
+
+
+def update_image_overlay_source(self, context):
+    """Re-apply the overlay for a newly selected source (keeps it visible)."""
+    from .core import overlay
+
+    overlay.refresh(context)
+    if self.show_image_overlay:
+        overlay.ensure_material_preview(context)
 
 
 def update_image_overlay_appearance(self, context):
@@ -231,14 +249,14 @@ class KinoraProperties(PropertyGroup):
         name="Show Background Overlay",
         description="Display a pre-computed bitmap (e.g. density) on the ground plane",
         default=False,
-        update=update_image_overlay,
+        update=update_image_overlay_visibility,
     )
 
     image_overlay_source: EnumProperty(
         name="Source",
         description="Which background image from the loaded file to display",
         items=_image_overlay_source_items,
-        update=update_image_overlay,
+        update=update_image_overlay_source,
     )
 
     image_overlay_colormap: EnumProperty(

--- a/kinora/__init__.py
+++ b/kinora/__init__.py
@@ -3,6 +3,7 @@
 A Blender addon for visualising pedestrian data trajectory files (JuPedSim SQLite and HDF5).
 """
 
+import json
 import os
 
 from . import install_utils
@@ -27,6 +28,7 @@ bl_info = {
 import bpy
 from bpy.props import (
     BoolProperty,
+    EnumProperty,
     FloatProperty,
     IntProperty,
     PointerProperty,
@@ -70,6 +72,48 @@ def update_geometry_thickness(self, context):
     for obj in collection.objects:
         if obj.type == "CURVE":
             obj.data.bevel_depth = self.geometry_thickness
+
+
+def parse_advanced_vis_manifest(props):
+    """Return the parsed advanced-visualisation manifest, or an empty one.
+
+    The manifest is stored as a JSON string on the scene so it persists with the
+    .blend and can be read cheaply from poll()/draw() and enum callbacks.
+    """
+    raw = props.adv_vis_manifest if props else ""
+    if not raw:
+        return {"backgrounds": []}
+    try:
+        manifest = json.loads(raw)
+    except (ValueError, TypeError):
+        return {"backgrounds": []}
+    if not isinstance(manifest, dict):
+        return {"backgrounds": []}
+    manifest.setdefault("backgrounds", [])
+    return manifest
+
+
+# Blender garbage-collects strings returned by an EnumProperty items callback
+# unless we keep our own reference, which can crash the UI.  Cache the last
+# returned list here to keep the identifier/name strings alive.
+_image_overlay_enum_cache = [("NONE", "None", "")]
+
+
+def _image_overlay_source_items(self, context):
+    """Build the background-image dropdown from the loaded file's manifest.
+
+    Each available background source becomes one selectable item; only one can
+    be active at a time.  Falls back to a single placeholder when nothing is
+    available so the property always has a valid value.
+    """
+    global _image_overlay_enum_cache
+    items = [
+        (bg["id"], bg.get("label", bg["id"]), bg.get("data_path", ""))
+        for bg in parse_advanced_vis_manifest(self).get("backgrounds", [])
+        if bg.get("id")
+    ]
+    _image_overlay_enum_cache = items or [("NONE", "None", "")]
+    return _image_overlay_enum_cache
 
 
 class KinoraProperties(PropertyGroup):
@@ -158,6 +202,26 @@ class KinoraProperties(PropertyGroup):
         default=0,
         min=0,
         options={"HIDDEN"},
+    )
+
+    # --- Advanced visualisations -------------------------------------------
+    adv_vis_manifest: StringProperty(
+        name="Advanced Visualisation Manifest",
+        description="JSON describing optional visualisation data in the loaded file",
+        default="",
+        options={"HIDDEN"},
+    )
+
+    show_image_overlay: BoolProperty(
+        name="Show Background Overlay",
+        description="Display a pre-computed bitmap (e.g. density) on the ground plane",
+        default=False,
+    )
+
+    image_overlay_source: EnumProperty(
+        name="Source",
+        description="Which background image from the loaded file to display",
+        items=_image_overlay_source_items,
     )
 
 

--- a/kinora/__init__.py
+++ b/kinora/__init__.py
@@ -38,6 +38,7 @@ from bpy.types import PropertyGroup
 
 # Import submodules
 from . import operators, panels, preferences
+from .core import colormaps
 
 
 def update_path_visibility(self, context):
@@ -72,6 +73,20 @@ def update_geometry_thickness(self, context):
     for obj in collection.objects:
         if obj.type == "CURVE":
             obj.data.bevel_depth = self.geometry_thickness
+
+
+def update_image_overlay(self, context):
+    """Apply, update, or remove the background overlay when settings change."""
+    from .core import overlay
+
+    overlay.refresh(context)
+
+
+def update_image_overlay_appearance(self, context):
+    """Update overlay colour map / interpolation without re-reading the file."""
+    from .core import overlay
+
+    overlay.update_appearance(context)
 
 
 def parse_advanced_vis_manifest(props):
@@ -216,12 +231,30 @@ class KinoraProperties(PropertyGroup):
         name="Show Background Overlay",
         description="Display a pre-computed bitmap (e.g. density) on the ground plane",
         default=False,
+        update=update_image_overlay,
     )
 
     image_overlay_source: EnumProperty(
         name="Source",
         description="Which background image from the loaded file to display",
         items=_image_overlay_source_items,
+        update=update_image_overlay,
+    )
+
+    image_overlay_colormap: EnumProperty(
+        name="Colour Scheme",
+        description="Colour map applied to the background image values",
+        items=colormaps.COLORMAP_ITEMS,
+        default=colormaps.DEFAULT_COLORMAP,
+        update=update_image_overlay_appearance,
+    )
+
+    image_overlay_interpolation: EnumProperty(
+        name="Interpolation",
+        description="How background image pixels are interpolated on the ground plane",
+        items=colormaps.INTERPOLATION_ITEMS,
+        default=colormaps.DEFAULT_INTERPOLATION,
+        update=update_image_overlay_appearance,
     )
 
 

--- a/kinora/core/colormaps.py
+++ b/kinora/core/colormaps.py
@@ -1,0 +1,183 @@
+"""Colour maps for the background-image overlay, baked from matplotlib offline.
+
+Runtime has no matplotlib (it does not play well inside Blender), so each colour
+map is stored here as a small set of sRGB stops and applied to a Blender
+``ColorRamp`` node in the shader.  The overlay image carries the raw scalar
+field; the ColorRamp turns value into colour, so switching colour map or
+interpolation never re-reads the data.
+
+Data contract: the overlay assumes the image values are already normalised to
+the range [0, 1] by the upstream data processing and simply clips at 1.  No
+min/max rescaling happens in the addon (see ``core/overlay.py``).
+"""
+
+# Auto-generated sRGB colour-map stops (position, (r, g, b)). Do not hand-edit;
+# regenerate from matplotlib with tools/dump_hdf5_images-style sampling.
+_STOPS = {
+    "GRAY": ((0.0, (0.0, 0.0, 0.0)), (1.0, (1.0, 1.0, 1.0))),
+    "VIRIDIS": (
+        (0.0, (0.267, 0.0049, 0.3294)),
+        (0.0625, (0.2823, 0.095, 0.4173)),
+        (0.125, (0.2788, 0.1755, 0.4834)),
+        (0.1875, (0.259, 0.2515, 0.5247)),
+        (0.25, (0.2297, 0.3224, 0.5457)),
+        (0.3125, (0.1994, 0.3876, 0.5546)),
+        (0.375, (0.1727, 0.4488, 0.5579)),
+        (0.4375, (0.149, 0.5081, 0.5573)),
+        (0.5, (0.1276, 0.5669, 0.5506)),
+        (0.5625, (0.1206, 0.6258, 0.5335)),
+        (0.625, (0.1579, 0.6838, 0.5017)),
+        (0.6875, (0.2461, 0.7389, 0.452)),
+        (0.75, (0.3692, 0.7889, 0.3829)),
+        (0.8125, (0.516, 0.8312, 0.2943)),
+        (0.875, (0.6785, 0.8637, 0.1895)),
+        (0.9375, (0.8456, 0.8873, 0.0997)),
+        (1.0, (0.9932, 0.9062, 0.1439)),
+    ),
+    "INFERNO": (
+        (0.0, (0.0015, 0.0005, 0.0139)),
+        (0.0625, (0.0423, 0.0281, 0.1411)),
+        (0.125, (0.1293, 0.0473, 0.2908)),
+        (0.1875, (0.2383, 0.0366, 0.3964)),
+        (0.25, (0.3415, 0.0623, 0.4294)),
+        (0.3125, (0.4412, 0.0993, 0.4316)),
+        (0.375, (0.5409, 0.1347, 0.4151)),
+        (0.4375, (0.6401, 0.1714, 0.3811)),
+        (0.5, (0.7357, 0.2159, 0.3302)),
+        (0.5625, (0.8224, 0.2752, 0.2661)),
+        (0.625, (0.8943, 0.3534, 0.1936)),
+        (0.6875, (0.947, 0.4492, 0.1153)),
+        (0.75, (0.9784, 0.5579, 0.0349)),
+        (0.8125, (0.9879, 0.6753, 0.0653)),
+        (0.875, (0.9746, 0.7977, 0.2063)),
+        (0.9375, (0.9476, 0.9174, 0.4107)),
+        (1.0, (0.9884, 0.9984, 0.6449)),
+    ),
+    "MAGMA": (
+        (0.0, (0.0015, 0.0005, 0.0139)),
+        (0.0625, (0.0396, 0.0311, 0.1335)),
+        (0.125, (0.1131, 0.0655, 0.2768)),
+        (0.1875, (0.2117, 0.062, 0.4186)),
+        (0.25, (0.3167, 0.0717, 0.4854)),
+        (0.3125, (0.4147, 0.1104, 0.5047)),
+        (0.375, (0.5128, 0.1482, 0.5076)),
+        (0.4375, (0.6136, 0.1818, 0.4985)),
+        (0.5, (0.7164, 0.215, 0.4753)),
+        (0.5625, (0.8169, 0.2559, 0.4365)),
+        (0.625, (0.9043, 0.3196, 0.3881)),
+        (0.6875, (0.9609, 0.4183, 0.3596)),
+        (0.75, (0.9867, 0.5356, 0.3822)),
+        (0.8125, (0.9961, 0.6537, 0.4462)),
+        (0.875, (0.9969, 0.7696, 0.5349)),
+        (0.9375, (0.9924, 0.8843, 0.6401)),
+        (1.0, (0.9871, 0.9914, 0.7495)),
+    ),
+    "TURBO": (
+        (0.0, (0.19, 0.0718, 0.2322)),
+        (0.0625, (0.2511, 0.2524, 0.6337)),
+        (0.125, (0.2763, 0.4212, 0.8912)),
+        (0.1875, (0.2586, 0.5796, 0.9988)),
+        (0.25, (0.1584, 0.7355, 0.9231)),
+        (0.3125, (0.0927, 0.8655, 0.7623)),
+        (0.375, (0.1966, 0.949, 0.5947)),
+        (0.4375, (0.4278, 0.9942, 0.3857)),
+        (0.5, (0.6436, 0.99, 0.2336)),
+        (0.5625, (0.8047, 0.9245, 0.2046)),
+        (0.625, (0.933, 0.8124, 0.2267)),
+        (0.6875, (0.9931, 0.6741, 0.2035)),
+        (0.75, (0.9836, 0.4929, 0.1285)),
+        (0.8125, (0.9211, 0.3149, 0.0548)),
+        (0.875, (0.8161, 0.1846, 0.0181)),
+        (0.9375, (0.6645, 0.0844, 0.0042)),
+        (1.0, (0.4796, 0.0158, 0.0106)),
+    ),
+    "HOT": (
+        (0.0, (0.0416, 0.0, 0.0)),
+        (0.0625, (0.2063, 0.0, 0.0)),
+        (0.125, (0.371, 0.0, 0.0)),
+        (0.1875, (0.5358, 0.0, 0.0)),
+        (0.25, (0.7005, 0.0, 0.0)),
+        (0.3125, (0.8652, 0.0, 0.0)),
+        (0.375, (1.0, 0.0299, 0.0)),
+        (0.4375, (1.0, 0.1946, 0.0)),
+        (0.5, (1.0, 0.3593, 0.0)),
+        (0.5625, (1.0, 0.524, 0.0)),
+        (0.625, (1.0, 0.6887, 0.0)),
+        (0.6875, (1.0, 0.8534, 0.0)),
+        (0.75, (1.0, 1.0, 0.0272)),
+        (0.8125, (1.0, 1.0, 0.2743)),
+        (0.875, (1.0, 1.0, 0.5213)),
+        (0.9375, (1.0, 1.0, 0.7684)),
+        (1.0, (1.0, 1.0, 1.0)),
+    ),
+    "CIVIDIS": (
+        (0.0, (0.0, 0.1351, 0.3048)),
+        (0.0625, (0.0, 0.1788, 0.4148)),
+        (0.125, (0.1034, 0.2204, 0.4358)),
+        (0.1875, (0.1951, 0.2644, 0.4259)),
+        (0.25, (0.2637, 0.3078, 0.4228)),
+        (0.3125, (0.3242, 0.3513, 0.4263)),
+        (0.375, (0.3808, 0.3952, 0.4357)),
+        (0.4375, (0.4352, 0.4398, 0.4511)),
+        (0.5, (0.4887, 0.4853, 0.471)),
+        (0.5625, (0.5478, 0.5319, 0.4717)),
+        (0.625, (0.6091, 0.5798, 0.4636)),
+        (0.6875, (0.672, 0.6293, 0.448)),
+        (0.75, (0.7365, 0.6806, 0.424)),
+        (0.8125, (0.8027, 0.734, 0.3902)),
+        (0.875, (0.8707, 0.7896, 0.3433)),
+        (0.9375, (0.9411, 0.8475, 0.2758)),
+        (1.0, (0.9957, 0.9093, 0.2178)),
+    ),
+}
+
+# Enum items (identifier, label, description) for the colour-scheme selector.
+COLORMAP_ITEMS = [
+    ("VIRIDIS", "Viridis", "Perceptually uniform blue-green-yellow"),
+    ("INFERNO", "Inferno", "Perceptually uniform black-red-yellow"),
+    ("MAGMA", "Magma", "Perceptually uniform black-purple-white"),
+    ("TURBO", "Turbo", "High-contrast rainbow (improved jet)"),
+    ("HOT", "Hot", "Black-red-yellow-white heat scale"),
+    ("CIVIDIS", "Cividis", "Colour-vision-deficiency friendly"),
+    ("GRAY", "Grayscale", "Black to white"),
+]
+
+# Enum items for the interpolation selector.  Identifiers match Blender's
+# ShaderNodeTexImage.interpolation values so they can be assigned directly.
+INTERPOLATION_ITEMS = [
+    ("Linear", "Linear (smooth)", "Bilinear smoothing between grid cells"),
+    ("Closest", "Closest (blocky)", "Show raw grid cells without smoothing"),
+    ("Cubic", "Cubic (smoothest)", "Cubic smoothing between grid cells"),
+]
+
+DEFAULT_COLORMAP = "VIRIDIS"
+DEFAULT_INTERPOLATION = "Linear"
+
+
+def _srgb_to_linear(channel):
+    """Convert one sRGB channel (0..1) to scene-linear."""
+    if channel <= 0.04045:
+        return channel / 12.92
+    return ((channel + 0.055) / 1.055) ** 2.4
+
+
+def apply_colormap(color_ramp, name):
+    """Configure a Blender ColorRamp's stops to match colour map *name*.
+
+    Stop colours are converted sRGB -> scene-linear so they display correctly
+    under a Standard/sRGB view transform.  (Blender's default AgX/Filmic view
+    transform will still tone-map them; switch to Standard for exact colours.)
+    """
+    stops = _STOPS.get(name) or _STOPS[DEFAULT_COLORMAP]
+    elements = color_ramp.elements
+    # A ColorRamp must keep at least one element; trim down then rebuild.
+    while len(elements) > 1:
+        elements.remove(elements[-1])
+    first_position, first_rgb = stops[0]
+    elements[0].position = first_position
+    elements[0].color = (*(_srgb_to_linear(c) for c in first_rgb), 1.0)
+    for position, rgb in stops[1:]:
+        element = elements.new(position)
+        element.color = (*(_srgb_to_linear(c) for c in rgb), 1.0)
+    color_ramp.color_mode = "RGB"
+    color_ramp.interpolation = "LINEAR"

--- a/kinora/core/geometry.py
+++ b/kinora/core/geometry.py
@@ -86,6 +86,9 @@ def create_geometry(context, geometry, collection, mat_cache):
         bm.free()
         plane_obj = bpy.data.objects.new("Kinora_Ground_Plane", plane_mesh)
         plane_obj.location = (0.0, 0.0, 0.0)
+        # Record the (unpadded) walkable-area bounds so the background-image
+        # overlay can UV-map a bitmap onto the exact geometry extent.
+        plane_obj["kinora_geo_bounds"] = [bounds[0], bounds[1], bounds[2], bounds[3]]
         plane_material = get_or_create_material(
             mat_cache, "Kinora_Ground_Plane_Material", (0.85, 0.85, 0.85, 1.0)
         )
@@ -180,7 +183,13 @@ def clear_all_kinora_artefacts():
             bpy.data.collections.remove(coll)
 
     # Purge Kinora datablocks orphaned by the object removals.
-    for datablocks in (bpy.data.meshes, bpy.data.curves, bpy.data.materials, bpy.data.particles):
+    for datablocks in (
+        bpy.data.meshes,
+        bpy.data.curves,
+        bpy.data.materials,
+        bpy.data.particles,
+        bpy.data.images,
+    ):
         for block in list(datablocks):
             if block.users == 0 and _is_kinora_name(block.name):
                 datablocks.remove(block)

--- a/kinora/core/overlay.py
+++ b/kinora/core/overlay.py
@@ -1,0 +1,241 @@
+"""Background image overlay: render a pre-computed bitmap on the ground plane.
+
+Element 2 renders the *static* background source as a grayscale, shadeless
+(emission) texture on the existing ``Kinora_Ground_Plane``.  The image is mapped
+to the walkable-area bounding box via a UV layer and clipped outside it, so the
+10% padding ring keeps the plane's neutral grey.
+
+Deliberately left for later elements:
+  * animated (per-frame) sources and timeline sync  (Element 3)
+  * value -> colour mapping beyond grayscale          (Element 4)
+"""
+
+import json
+
+import bpy
+import numpy as np
+
+from . import colormaps
+
+GROUND_PLANE_NAME = "Kinora_Ground_Plane"
+OVERLAY_IMAGE_NAME = "Kinora_Overlay_Image"
+OVERLAY_MATERIAL_NAME = "Kinora_Ground_Overlay_Material"
+BASE_MATERIAL_NAME = "Kinora_Ground_Plane_Material"
+OVERLAY_UV_NAME = "Kinora_Overlay_UV"
+OVERLAY_TEX_NODE = "Kinora_Overlay_Tex"
+OVERLAY_RAMP_NODE = "Kinora_Overlay_Ramp"
+GEO_BOUNDS_KEY = "kinora_geo_bounds"
+
+
+def _selected_source(props):
+    """Return the manifest entry for the chosen background, or None."""
+    raw = props.adv_vis_manifest
+    if not raw:
+        return None
+    try:
+        manifest = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    source_id = props.image_overlay_source
+    for background in manifest.get("backgrounds", []):
+        if background.get("id") == source_id:
+            return background
+    return None
+
+
+def _read_static_values(h5_path, data_path):
+    """Read a 2-D background bitmap ``(rows, cols)`` from the HDF5 file."""
+    import h5py
+
+    with h5py.File(h5_path, "r") as f:
+        return np.asarray(f[data_path][:], dtype=np.float32)
+
+
+def _values_to_pixels(values):
+    """Map a ``(rows, cols)`` scalar field to a bottom-up grayscale RGBA buffer.
+
+    The buffer stores the raw value (R=G=B=value, alpha=1); the shader's
+    ColorRamp turns value into colour, so colour-map changes need no rebuild.
+
+    Normalisation is the upstream data processing's responsibility: values are
+    assumed to be in [0, 1] and are simply clipped here (clip at 1).  No min/max
+    rescaling is applied.
+
+    The HDF5 image is stored top-down (row 0 = world y-max), so it is flipped to
+    Blender's bottom-up pixel order.
+    """
+    norm = np.clip(values, 0.0, 1.0)
+    norm = np.flipud(norm)  # top-down HDF5 -> bottom-up Blender
+    height, width = norm.shape
+    pixels = np.ones((height, width, 4), dtype=np.float32)
+    pixels[..., 0] = norm
+    pixels[..., 1] = norm
+    pixels[..., 2] = norm
+    return pixels
+
+
+def _get_overlay_image(values):
+    """Create or refresh the Blender image datablock holding the bitmap."""
+    pixels = _values_to_pixels(values)
+    height, width = pixels.shape[0], pixels.shape[1]
+    image = bpy.data.images.get(OVERLAY_IMAGE_NAME)
+    if image is not None and tuple(image.size) != (width, height):
+        bpy.data.images.remove(image)
+        image = None
+    if image is None:
+        image = bpy.data.images.new(
+            OVERLAY_IMAGE_NAME, width=width, height=height, alpha=True, float_buffer=True
+        )
+    # Treat the stored values as raw data, not sRGB-encoded colour.
+    image.colorspace_settings.name = "Non-Color"
+    image.pixels.foreach_set(pixels.ravel())
+    image.update()
+    return image
+
+
+def _build_overlay_material(image, colormap, interpolation):
+    """Build the shadeless overlay material: image inside the bbox, grey outside.
+
+    The raw image value feeds a ColorRamp (the *colormap*); the resulting colour
+    drives an emission shader.  The image's clipped alpha mixes between a neutral
+    grey emission (padding ring) and the bitmap emission (over the walkable
+    area).  *interpolation* is the image-texture sampling mode.
+    """
+    material = bpy.data.materials.get(OVERLAY_MATERIAL_NAME)
+    if material is None:
+        material = bpy.data.materials.new(OVERLAY_MATERIAL_NAME)
+    material.use_nodes = True
+    tree = material.node_tree
+    tree.nodes.clear()
+
+    output = tree.nodes.new("ShaderNodeOutputMaterial")
+    output.location = (600, 0)
+
+    tex = tree.nodes.new("ShaderNodeTexImage")
+    tex.name = OVERLAY_TEX_NODE
+    tex.image = image
+    tex.extension = "CLIP"  # transparent outside [0, 1] UV -> shows grey base
+    tex.interpolation = interpolation
+    tex.location = (-500, 0)
+
+    ramp = tree.nodes.new("ShaderNodeValToRGB")  # ColorRamp = value -> colour
+    ramp.name = OVERLAY_RAMP_NODE
+    ramp.location = (-220, 0)
+    colormaps.apply_colormap(ramp.color_ramp, colormap)
+
+    image_emit = tree.nodes.new("ShaderNodeEmission")
+    image_emit.location = (100, 150)
+
+    base_emit = tree.nodes.new("ShaderNodeEmission")
+    base_emit.inputs["Color"].default_value = (0.85, 0.85, 0.85, 1.0)
+    base_emit.location = (100, -150)
+
+    mix = tree.nodes.new("ShaderNodeMixShader")
+    mix.location = (350, 0)
+
+    links = tree.links
+    links.new(tex.outputs["Color"], ramp.inputs["Fac"])
+    links.new(ramp.outputs["Color"], image_emit.inputs["Color"])
+    links.new(tex.outputs["Alpha"], mix.inputs[0])  # Fac
+    links.new(base_emit.outputs["Emission"], mix.inputs[1])
+    links.new(image_emit.outputs["Emission"], mix.inputs[2])
+    links.new(mix.outputs["Shader"], output.inputs["Surface"])
+    return material
+
+
+def _ensure_plane_uv(plane):
+    """Map the walkable-area bounding box onto image UV ``[0, 1]``.
+
+    Padding around the geometry lands outside ``[0, 1]`` and is clipped.  Returns
+    False if the plane lacks usable stored bounds.
+    """
+    raw = plane.get(GEO_BOUNDS_KEY)
+    if raw is None:
+        return False
+    gx0, gy0, gx1, gy1 = (float(v) for v in raw)
+    span_x = gx1 - gx0
+    span_y = gy1 - gy0
+    if span_x <= 0.0 or span_y <= 0.0:
+        return False
+
+    mesh = plane.data
+    uv = mesh.uv_layers.get(OVERLAY_UV_NAME) or mesh.uv_layers.new(name=OVERLAY_UV_NAME)
+    mesh.uv_layers.active = uv
+    # The plane is created at the origin with vertices in world coordinates, so
+    # local vertex positions are world positions.
+    for loop in mesh.loops:
+        co = mesh.vertices[loop.vertex_index].co
+        uv.data[loop.index].uv = ((co.x - gx0) / span_x, (co.y - gy0) / span_y)
+    return True
+
+
+def _assign_material(obj, material):
+    obj.data.materials.clear()
+    obj.data.materials.append(material)
+
+
+def _restore_base(plane):
+    """Reassign the plain grey ground-plane material, hiding any overlay."""
+    base = bpy.data.materials.get(BASE_MATERIAL_NAME)
+    if base is not None:
+        _assign_material(plane, base)
+
+
+def refresh(context):
+    """Apply or update the background overlay according to current properties.
+
+    Safe to call any time: no plane, overlay off, or an animated/invalid source
+    simply restores the plain grey plane.  Errors reading the file are reported
+    and never raised, so a bad overlay can't break interaction.
+    """
+    props = context.scene.kinora_props
+    plane = bpy.data.objects.get(GROUND_PLANE_NAME)
+    if plane is None:
+        return
+
+    if not props.show_image_overlay:
+        _restore_base(plane)
+        return
+
+    source = _selected_source(props)
+    h5_path = bpy.path.abspath(props.sqlite_file) if props.sqlite_file else ""
+    # Animated sources arrive in Element 3; only static is rendered for now.
+    if source is None or source.get("kind") != "static" or not h5_path:
+        _restore_base(plane)
+        return
+
+    try:
+        values = _read_static_values(h5_path, source["data_path"])
+    except Exception as exc:  # noqa: BLE001 - overlay must never break loading/UI
+        print(f"[Kinora] Failed to read background image: {exc}")
+        _restore_base(plane)
+        return
+
+    image = _get_overlay_image(values)
+    if not _ensure_plane_uv(plane):
+        _restore_base(plane)
+        return
+    material = _build_overlay_material(
+        image, props.image_overlay_colormap, props.image_overlay_interpolation
+    )
+    _assign_material(plane, material)
+
+
+def update_appearance(context):
+    """Update colour map / interpolation on the existing overlay material.
+
+    A lightweight companion to :func:`refresh`: changes presentation only, with
+    no file read or image rebuild, so the colour-scheme and interpolation enums
+    update live.  No-op when the overlay material does not exist yet.
+    """
+    material = bpy.data.materials.get(OVERLAY_MATERIAL_NAME)
+    if material is None or not material.use_nodes:
+        return
+    props = context.scene.kinora_props
+    nodes = material.node_tree.nodes
+    tex = nodes.get(OVERLAY_TEX_NODE)
+    if tex is not None:
+        tex.interpolation = props.image_overlay_interpolation
+    ramp = nodes.get(OVERLAY_RAMP_NODE)
+    if ramp is not None:
+        colormaps.apply_colormap(ramp.color_ramp, props.image_overlay_colormap)

--- a/kinora/core/overlay.py
+++ b/kinora/core/overlay.py
@@ -1,13 +1,15 @@
 """Background image overlay: render a pre-computed bitmap on the ground plane.
 
-Element 2 renders the *static* background source as a grayscale, shadeless
-(emission) texture on the existing ``Kinora_Ground_Plane``.  The image is mapped
-to the walkable-area bounding box via a UV layer and clipped outside it, so the
-10% padding ring keeps the plane's neutral grey.
+The selected background source (static ``image_data`` or animated
+``image_frame_data``) is drawn as a shadeless (emission) texture on the existing
+``Kinora_Ground_Plane``.  The raw value feeds a ColorRamp (the colour scheme) and
+is sampled with the chosen interpolation; the image is UV-mapped to the
+walkable-area bounding box and clipped outside it, so the 10% padding ring keeps
+the plane's neutral grey.  Animated sources are preloaded and swapped per frame
+by a frame-change handler kept in sync with the agent streaming.
 
-Deliberately left for later elements:
-  * animated (per-frame) sources and timeline sync  (Element 3)
-  * value -> colour mapping beyond grayscale          (Element 4)
+Values are assumed pre-normalised to [0, 1] upstream (clipped here, no
+rescaling); see ``_values_to_pixels``.
 """
 
 import json
@@ -74,10 +76,15 @@ def _values_to_pixels(values):
     return pixels
 
 
+def _write_pixels(image, values):
+    """Write a ``(rows, cols)`` scalar field into an existing overlay image."""
+    image.pixels.foreach_set(_values_to_pixels(values).ravel())
+    image.update()
+
+
 def _get_overlay_image(values):
     """Create or refresh the Blender image datablock holding the bitmap."""
-    pixels = _values_to_pixels(values)
-    height, width = pixels.shape[0], pixels.shape[1]
+    height, width = values.shape
     image = bpy.data.images.get(OVERLAY_IMAGE_NAME)
     if image is not None and tuple(image.size) != (width, height):
         bpy.data.images.remove(image)
@@ -88,8 +95,7 @@ def _get_overlay_image(values):
         )
     # Treat the stored values as raw data, not sRGB-encoded colour.
     image.colorspace_settings.name = "Non-Color"
-    image.pixels.foreach_set(pixels.ravel())
-    image.update()
+    _write_pixels(image, values)
     return image
 
 
@@ -181,29 +187,75 @@ def _restore_base(plane):
         _assign_material(plane, base)
 
 
+def _set_viewport_shading(context, from_types, to_type):
+    """Set 3D viewports currently in *from_types* to *to_type*.
+
+    No-op in headless/background mode (no windows).
+    """
+    wm = getattr(context, "window_manager", None) or bpy.context.window_manager
+    if wm is None:
+        return
+    for window in wm.windows:
+        for area in window.screen.areas:
+            if area.type != "VIEW_3D":
+                continue
+            for space in area.spaces:
+                if space.type == "VIEW_3D" and space.shading.type in from_types:
+                    space.shading.type = to_type
+
+
+def ensure_material_preview(context):
+    """Switch Solid/Wireframe viewports to Material Preview so the overlay shows.
+
+    The overlay is an emission material that Solid/Wireframe shading does not
+    display, so an enabled overlay would look like it failed to load.  Viewports
+    already in Rendered (which also show the overlay) are left untouched.
+    """
+    _set_viewport_shading(context, {"WIREFRAME", "SOLID"}, "MATERIAL")
+
+
+def restore_solid_shading(context):
+    """Revert Material-Preview viewports to Solid when the overlay is hidden.
+
+    Companion to :func:`ensure_material_preview`; only affects viewports
+    currently in Material Preview, leaving Rendered (and anything else) as the
+    user set them.
+    """
+    _set_viewport_shading(context, {"MATERIAL"}, "SOLID")
+
+
 def refresh(context):
     """Apply or update the background overlay according to current properties.
 
-    Safe to call any time: no plane, overlay off, or an animated/invalid source
-    simply restores the plain grey plane.  Errors reading the file are reported
-    and never raised, so a bad overlay can't break interaction.
+    Safe to call any time: no plane, overlay off, or an invalid source simply
+    restores the plain grey plane.  Errors reading the file are reported and
+    never raised, so a bad overlay can't break interaction.
     """
     props = context.scene.kinora_props
     plane = bpy.data.objects.get(GROUND_PLANE_NAME)
     if plane is None:
+        _clear_animation()
         return
 
     if not props.show_image_overlay:
+        _clear_animation()
         _restore_base(plane)
         return
 
     source = _selected_source(props)
     h5_path = bpy.path.abspath(props.sqlite_file) if props.sqlite_file else ""
-    # Animated sources arrive in Element 3; only static is rendered for now.
-    if source is None or source.get("kind") != "static" or not h5_path:
+    if source is None or not h5_path:
+        _clear_animation()
         _restore_base(plane)
         return
 
+    kind = source.get("kind")
+    if kind == "animated":
+        _refresh_animated(context, props, plane, source, h5_path)
+        return
+
+    # Static (default) source.
+    _clear_animation()
     try:
         values = _read_static_values(h5_path, source["data_path"])
     except Exception as exc:  # noqa: BLE001 - overlay must never break loading/UI
@@ -212,13 +264,145 @@ def refresh(context):
         return
 
     image = _get_overlay_image(values)
-    if not _ensure_plane_uv(plane):
+    if not _build_and_assign(plane, image, props):
         _restore_base(plane)
-        return
+
+
+def _build_and_assign(plane, image, props):
+    """UV-map the plane and assign the overlay material.  False if no UVs."""
+    if not _ensure_plane_uv(plane):
+        return False
     material = _build_overlay_material(
         image, props.image_overlay_colormap, props.image_overlay_interpolation
     )
     _assign_material(plane, material)
+    return True
+
+
+# --- Animated source --------------------------------------------------------
+# Per-frame bitmaps are preloaded into memory and swapped into the overlay image
+# by a frame-change handler, mapping Blender frames to data frames the same way
+# core.streaming maps agent positions (so the overlay stays in sync with agents).
+_ANIM = {
+    "active": False,
+    "stack": None,  # np.ndarray (T, H, W) float32, raw values
+    "frame_to_index": None,  # dict: data-frame number -> row index
+    "sorted_frames": None,  # np.ndarray of data-frame numbers, ascending
+    "last_index": -1,  # last row applied (skip redundant writes)
+}
+_anim_handler_installed = False
+
+
+def _read_animated(h5_path, source):
+    """Load the full per-frame stack and its frame-number index."""
+    import h5py
+
+    with h5py.File(h5_path, "r") as f:
+        stack = np.asarray(f[source["data_path"]][:], dtype=np.float32)  # (T, H, W)
+        frames = np.asarray(f[source["frames_path"]][:]).astype(np.int64)
+    return stack, frames
+
+
+def _refresh_animated(context, props, plane, source, h5_path):
+    """Activate the animated overlay: preload, build material, sync to timeline."""
+    try:
+        stack, frames = _read_animated(h5_path, source)
+    except Exception as exc:  # noqa: BLE001 - overlay must never break loading/UI
+        print(f"[Kinora] Failed to read animated background image: {exc}")
+        _clear_animation()
+        _restore_base(plane)
+        return
+    if stack.ndim != 3 or stack.shape[0] == 0:
+        _clear_animation()
+        _restore_base(plane)
+        return
+
+    _ANIM["stack"] = stack
+    _ANIM["sorted_frames"] = frames
+    _ANIM["frame_to_index"] = {int(fn): i for i, fn in enumerate(frames)}
+    _ANIM["last_index"] = -1
+    _ANIM["active"] = True
+
+    image = _get_overlay_image(stack[0])
+    if not _build_and_assign(plane, image, props):
+        _clear_animation()
+        _restore_base(plane)
+        return
+    _install_anim_handler()
+    _apply_anim_frame(context.scene)
+
+
+def _target_index(scene):
+    """Map the current Blender frame to a row in the preloaded stack."""
+    sorted_frames = _ANIM["sorted_frames"]
+    if sorted_frames is None or len(sorted_frames) == 0:
+        return None
+
+    # Mirror core.streaming's Blender-frame -> data-frame mapping so the overlay
+    # stays aligned with the agents.
+    from .streaming import STREAM_STATE
+
+    step = STREAM_STATE.get("frame_step") or 1
+    min_frame = STREAM_STATE.get("min_frame")
+    if min_frame is None:
+        min_frame = int(sorted_frames[0])
+    blender_frame = scene.frame_current
+    if step <= 1:
+        target = blender_frame
+    else:
+        target = min_frame + (blender_frame - scene.frame_start) * step
+
+    index = _ANIM["frame_to_index"].get(target)
+    if index is not None:
+        return index
+    # Nearest available frame when there is no exact match.
+    pos = int(np.searchsorted(sorted_frames, target))
+    pos = max(0, min(pos, len(sorted_frames) - 1))
+    if pos > 0 and abs(sorted_frames[pos - 1] - target) <= abs(sorted_frames[pos] - target):
+        pos -= 1
+    return pos
+
+
+def _apply_anim_frame(scene):
+    """Swap the overlay image to the frame matching the timeline position."""
+    if not _ANIM["active"]:
+        return
+    index = _target_index(scene)
+    if index is None or index == _ANIM["last_index"]:
+        return
+    image = bpy.data.images.get(OVERLAY_IMAGE_NAME)
+    if image is None:
+        return
+    _write_pixels(image, _ANIM["stack"][index])
+    _ANIM["last_index"] = index
+
+
+def _overlay_frame_handler(scene):
+    try:
+        _apply_anim_frame(scene)
+    except Exception as exc:  # noqa: BLE001 - never break playback
+        print(f"[Kinora] overlay frame update failed: {exc}")
+
+
+def _install_anim_handler():
+    global _anim_handler_installed
+    if not _anim_handler_installed:
+        bpy.app.handlers.frame_change_post.append(_overlay_frame_handler)
+        _anim_handler_installed = True
+
+
+def _clear_animation():
+    """Remove the frame handler and free preloaded animation state."""
+    global _anim_handler_installed
+    if _anim_handler_installed and _overlay_frame_handler in bpy.app.handlers.frame_change_post:
+        bpy.app.handlers.frame_change_post.remove(_overlay_frame_handler)
+    _anim_handler_installed = False
+    _ANIM.update(active=False, stack=None, frame_to_index=None, sorted_frames=None, last_index=-1)
+
+
+def clear_animation():
+    """Public hook to tear down animated-overlay state (load reset / unregister)."""
+    _clear_animation()
 
 
 def update_appearance(context):

--- a/kinora/io/hdf5_reader.py
+++ b/kinora/io/hdf5_reader.py
@@ -6,6 +6,64 @@ import time
 from typing import Any
 
 
+def probe_advanced_visualisations(path: pathlib.Path) -> dict[str, Any]:
+    """Scan an HDF5 file for optional Kinora "advanced visualisation" datasets.
+
+    Returns a manifest describing the extra, non-trajectory data a file provides
+    (currently background image bitmaps).  Datasets that are absent or have an
+    unexpected layout are simply skipped, so an ordinary trajectory file yields
+    an empty manifest and the Advanced Visualisations UI stays hidden.
+
+    The manifest is intentionally open-ended: ``backgrounds`` is a list of
+    self-describing option dicts so future source types slot in without changing
+    the consumers.
+    """
+    import h5py
+
+    backgrounds: list[dict[str, Any]] = []
+    try:
+        with h5py.File(path, "r") as f:
+            # Static, single-frame background bitmap.
+            static = f.get("image_data")
+            if isinstance(static, h5py.Dataset) and static.ndim == 2:
+                backgrounds.append(
+                    {
+                        "id": "image_data",
+                        "label": "Static image (image_data)",
+                        "kind": "static",
+                        "data_path": "image_data",
+                        "shape": list(static.shape),
+                    }
+                )
+
+            # Animated, per-frame background bitmap.
+            group = f.get("image_frame_data")
+            if isinstance(group, h5py.Group):
+                frames = group.get("data")
+                index = group.get("frame")
+                if (
+                    isinstance(frames, h5py.Dataset)
+                    and frames.ndim == 3
+                    and isinstance(index, h5py.Dataset)
+                ):
+                    backgrounds.append(
+                        {
+                            "id": "image_frame_data",
+                            "label": "Animated image (image_frame_data)",
+                            "kind": "animated",
+                            "data_path": "image_frame_data/data",
+                            "frames_path": "image_frame_data/frame",
+                            "shape": list(frames.shape),
+                        }
+                    )
+    except Exception:
+        # A malformed or unreadable file must never block trajectory loading;
+        # advanced visualisations are strictly optional.
+        return {"backgrounds": []}
+
+    return {"backgrounds": backgrounds}
+
+
 def read_simulation_data(
     path: pathlib.Path,
     frame_step: int,
@@ -82,6 +140,10 @@ def read_simulation_data(
 
     timings["load_hdf5_total"] = time.perf_counter() - start_total
 
+    start = time.perf_counter()
+    advanced_vis = probe_advanced_visualisations(path)
+    timings["probe_advanced_vis_hdf5"] = time.perf_counter() - start
+
     data = {
         "geometry": walkable.polygon,
         "agent_ids": agent_ids,
@@ -92,5 +154,6 @@ def read_simulation_data(
         "db_path": None,
         "frame_data": frame_data,
         "path_groups": path_groups,
+        "advanced_vis": advanced_vis,
     }
     return data, timings

--- a/kinora/operators.py
+++ b/kinora/operators.py
@@ -270,6 +270,7 @@ class KINORA_OT_load_simulation(Operator):
                 from .core import overlay
 
                 overlay.refresh(context)
+                overlay.ensure_material_preview(context)
             context.scene.frame_set(context.scene.frame_start)
             self._timed_end("finalize")
             props.loading_progress = 100.0
@@ -307,6 +308,9 @@ class KINORA_OT_load_simulation(Operator):
         self._path_groups = None
         self._materials = {}
         clear_stream_state()
+        from .core import overlay
+
+        overlay.clear_animation()
         # Start each load from a clean slate: remove all prior Kinora artefacts.
         geo.clear_all_kinora_artefacts()
 
@@ -485,5 +489,8 @@ def register() -> None:
 
 def unregister() -> None:
     clear_stream_state()
+    from .core import overlay
+
+    overlay.clear_animation()
     for cls in reversed(classes):
         bpy.utils.unregister_class(cls)

--- a/kinora/operators.py
+++ b/kinora/operators.py
@@ -3,6 +3,7 @@ Kinora Operators
 Operators for loading (JuPedSim) trajectory and geometry data.
 """
 
+import json
 import os
 import pathlib
 import threading
@@ -120,6 +121,7 @@ class KINORA_OT_load_simulation(Operator):
             return {"CANCELLED"}
 
         self._reset_state()
+        props.adv_vis_manifest = ""
         self._frame_step = props.frame_step
         self._big_data_mode = props.big_data_mode
         self._load_full_paths = props.load_full_paths
@@ -368,6 +370,7 @@ class KINORA_OT_load_simulation(Operator):
         self._max_frame = self._worker_data["max_frame"]
         self._sampled_frames = set()
         self._path_groups = self._worker_data.get("path_groups")
+        self._apply_advanced_vis(context)
         context.scene.kinora_props.loaded_agent_count = self._total_agents
         step = self._frame_step
         if step > 1:
@@ -381,6 +384,21 @@ class KINORA_OT_load_simulation(Operator):
             self._timings[key] = value
         if not self._big_data_mode:
             self._timed_start("create_agents")
+
+    def _apply_advanced_vis(self, context: Context) -> None:
+        """Publish the file's advanced-visualisation manifest to the scene.
+
+        Stores the manifest as JSON (driving the Advanced Visualisations panel's
+        visibility and the source dropdown) and selects the first available
+        background so the dropdown starts on a valid entry.  SQLite loads and
+        plain trajectory files clear it, hiding the panel.
+        """
+        props = context.scene.kinora_props
+        manifest = (self._worker_data or {}).get("advanced_vis") or {"backgrounds": []}
+        props.adv_vis_manifest = json.dumps(manifest)
+        backgrounds = manifest.get("backgrounds", [])
+        if backgrounds:
+            props.image_overlay_source = backgrounds[0]["id"]
 
     def _step_create_agents(self, context: Context) -> bool:
         """Create a batch of agent objects per tick."""

--- a/kinora/operators.py
+++ b/kinora/operators.py
@@ -266,6 +266,10 @@ class KINORA_OT_load_simulation(Operator):
                     objects=objects,
                     frame_data=self._worker_data.get("frame_data"),
                 )
+            if props.show_image_overlay:
+                from .core import overlay
+
+                overlay.refresh(context)
             context.scene.frame_set(context.scene.frame_start)
             self._timed_end("finalize")
             props.loading_progress = 100.0

--- a/kinora/panels.py
+++ b/kinora/panels.py
@@ -112,6 +112,38 @@ class KINORA_PT_main_panel(Panel):
         box.label(text="Geometry → Curve boundaries")
 
 
+class KINORA_PT_advanced_vis_panel(Panel):
+    """Advanced visualisation options, shown only when the file provides them."""
+
+    bl_label = "Advanced Visualisations"
+    bl_idname = "KINORA_PT_advanced_vis_panel"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "Kinora"
+    bl_options = {"DEFAULT_CLOSED"}
+
+    @classmethod
+    def poll(cls, context: Context) -> bool:
+        from . import parse_advanced_vis_manifest
+
+        props = getattr(context.scene, "kinora_props", None)
+        if not props:
+            return False
+        manifest = parse_advanced_vis_manifest(props)
+        return bool(manifest.get("backgrounds"))
+
+    def draw(self, context: Context) -> None:
+        layout = self.layout
+        props = context.scene.kinora_props
+
+        box = layout.box()
+        box.label(text="Background Image", icon="IMAGE_DATA")
+        box.prop(props, "show_image_overlay", text="Show Overlay")
+        col = box.column()
+        col.enabled = props.show_image_overlay
+        col.prop(props, "image_overlay_source", text="Source")
+
+
 class KINORA_PT_info_panel(Panel):
     """Info panel showing loaded simulation statistics."""
 
@@ -145,6 +177,7 @@ class KINORA_PT_info_panel(Panel):
 
 classes = [
     KINORA_PT_main_panel,
+    KINORA_PT_advanced_vis_panel,
     KINORA_PT_info_panel,
 ]
 

--- a/kinora/panels.py
+++ b/kinora/panels.py
@@ -142,6 +142,8 @@ class KINORA_PT_advanced_vis_panel(Panel):
         col = box.column()
         col.enabled = props.show_image_overlay
         col.prop(props, "image_overlay_source", text="Source")
+        col.prop(props, "image_overlay_colormap", text="Colour")
+        col.prop(props, "image_overlay_interpolation", text="Interp")
 
 
 class KINORA_PT_info_panel(Panel):

--- a/tools/dump_hdf5_images.py
+++ b/tools/dump_hdf5_images.py
@@ -1,0 +1,173 @@
+"""Standalone: dump every image in a Kinora HDF5 file to PNGs for inspection.
+
+Renders the static ``image_data`` and all animated ``image_frame_data`` frames so
+their appearance, colour mapping (tone mapping) and interpolation can be judged
+by eye before wiring choices into the Blender overlay shader.
+
+Run with a normal Python that has numpy + h5py + matplotlib + pillow (e.g. a
+conda env), NOT Blender's bundled Python:
+
+    python tools/dump_hdf5_images.py [path/to/file.h5] [output_dir]
+
+Outputs (default output dir: <temp>/kinora_image_dump):
+  static/   colour-map x interpolation comparison of image_data
+  animated/ every frame in a default colour map + an animated GIF + a montage
+  colourmaps_static.png / colourmaps_anim_peak.png  side-by-side comparisons
+
+Orientation note: HDF5 row 0 = world y-max, which is also PNG row 0 (top), so
+images are written as-is here (north up). Blender's pixel buffer is bottom-up,
+so the addon flips vertically instead.
+"""
+
+import os
+import sys
+import tempfile
+
+import h5py
+import matplotlib.pyplot as plt
+import numpy as np
+from PIL import Image, ImageDraw
+
+# --- configuration ----------------------------------------------------------
+COLOURMAPS = ["gray", "viridis", "inferno", "magma", "turbo", "hot", "cividis"]
+DEFAULT_ANIM_CMAP = "viridis"
+UPSCALE = 8                # integer pixel zoom for crisp viewing
+GIF_FPS = 15
+INTERP = {"nearest": Image.NEAREST, "bilinear": Image.BILINEAR}
+
+
+def colourize(field, cmap, vmin, vmax):
+    """Map a 2-D scalar field to an HxWx3 uint8 RGB image via a colour map."""
+    if vmax > vmin:
+        norm = np.clip((field - vmin) / (vmax - vmin), 0.0, 1.0)
+    else:
+        norm = np.zeros_like(field)
+    rgba = plt.get_cmap(cmap)(norm)
+    return (rgba[..., :3] * 255).astype(np.uint8)
+
+
+def upscale(rgb, factor, resample):
+    img = Image.fromarray(rgb)
+    return img.resize((img.width * factor, img.height * factor), resample=resample)
+
+
+def label(img, text):
+    """Return a copy of *img* with a caption bar at the top."""
+    bar = 18
+    out = Image.new("RGB", (img.width, img.height + bar), (20, 20, 20))
+    out.paste(img, (0, bar))
+    ImageDraw.Draw(out).text((4, 4), text, fill=(240, 240, 240))
+    return out
+
+
+def montage(tiles, cols, pad=6, bg=(30, 30, 30)):
+    """Arrange labelled PIL tiles (assumed equal size) into a grid image."""
+    if not tiles:
+        return None
+    tw, th = tiles[0].size
+    rows = (len(tiles) + cols - 1) // cols
+    canvas = Image.new(
+        "RGB", (cols * tw + (cols + 1) * pad, rows * th + (rows + 1) * pad), bg
+    )
+    for i, tile in enumerate(tiles):
+        r, c = divmod(i, cols)
+        canvas.paste(tile, (pad + c * (tw + pad), pad + r * (th + pad)))
+    return canvas
+
+
+def dump_static(values, out_dir):
+    """Colour-map x interpolation comparison + per-map PNGs for image_data."""
+    static_dir = os.path.join(out_dir, "static")
+    os.makedirs(static_dir, exist_ok=True)
+    vmin, vmax = 0.0, float(values.max())
+    print(f"static image_data: {values.shape}, range 0..{vmax:.4f}")
+
+    tiles = []
+    for cmap in COLOURMAPS:
+        rgb = colourize(values, cmap, vmin, vmax)
+        for interp_name, resample in INTERP.items():
+            tile = label(upscale(rgb, UPSCALE, resample), f"{cmap} / {interp_name}")
+            tiles.append(tile)
+        # also a standalone nearest PNG per colour map
+        upscale(rgb, UPSCALE, Image.NEAREST).save(
+            os.path.join(static_dir, f"image_data_{cmap}.png")
+        )
+    grid = montage(tiles, cols=len(INTERP))
+    grid.save(os.path.join(out_dir, "colourmaps_static.png"))
+    print(f"  wrote {len(COLOURMAPS)} PNGs + colourmaps_static.png")
+
+
+def dump_animated(frames, frame_idx, out_dir):
+    """Every frame in the default colour map + GIF + montage + colour compare."""
+    anim_dir = os.path.join(out_dir, "animated")
+    os.makedirs(anim_dir, exist_ok=True)
+    n = frames.shape[0]
+
+    # Robust global normalisation so frames are comparable over time.
+    vmin = 0.0
+    vmax = float(np.percentile(frames, 99.5))
+    print(f"animated: {frames.shape}, global norm 0..{vmax:.4f} (p99.5)")
+
+    gif_frames = []
+    for i in range(n):
+        rgb = colourize(frames[i], DEFAULT_ANIM_CMAP, vmin, vmax)
+        big = upscale(rgb, UPSCALE, Image.NEAREST)
+        fnum = int(frame_idx[i])
+        big.save(os.path.join(anim_dir, f"frame_{fnum:04d}.png"))
+        gif_frames.append(big)
+        if (i + 1) % 50 == 0 or i == n - 1:
+            print(f"  frame {i + 1}/{n}", end="\r")
+    print()
+
+    gif_frames[0].save(
+        os.path.join(out_dir, "animated.gif"),
+        save_all=True,
+        append_images=gif_frames[1:],
+        duration=int(1000 / GIF_FPS),
+        loop=0,
+        optimize=True,
+    )
+
+    # Montage: every Nth frame for a quick overview of the whole sequence.
+    step = max(1, n // 24)
+    overview = [
+        label(upscale(colourize(frames[i], DEFAULT_ANIM_CMAP, vmin, vmax), 4, Image.NEAREST),
+              f"f{int(frame_idx[i])}")
+        for i in range(0, n, step)
+    ]
+    montage(overview, cols=6).save(os.path.join(out_dir, "animated_overview.png"))
+
+    # Colour-map comparison on the peak-density frame.
+    peak = int(np.argmax(frames.max(axis=(1, 2))))
+    tiles = [
+        label(upscale(colourize(frames[peak], c, vmin, vmax), UPSCALE, Image.NEAREST), c)
+        for c in COLOURMAPS
+    ]
+    montage(tiles, cols=3).save(os.path.join(out_dir, "colourmaps_anim_peak.png"))
+    print(f"  wrote {n} frame PNGs + animated.gif + overview + peak compare (frame {int(frame_idx[peak])})")
+
+
+def main():
+    h5_path = sys.argv[1] if len(sys.argv) > 1 else os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "kinora", "examples", "trajectory_export.h5",
+    )
+    out_dir = sys.argv[2] if len(sys.argv) > 2 else os.path.join(
+        tempfile.gettempdir(), "kinora_image_dump"
+    )
+    os.makedirs(out_dir, exist_ok=True)
+    print(f"file:   {h5_path}")
+    print(f"output: {out_dir}\n")
+
+    with h5py.File(h5_path, "r") as f:
+        static = np.asarray(f["image_data"][:], dtype=np.float64)
+        frames = np.asarray(f["image_frame_data/data"][:], dtype=np.float64)
+        frame_idx = np.asarray(f["image_frame_data/frame"][:])
+
+    dump_static(static, out_dir)
+    dump_animated(frames, frame_idx, out_dir)
+    print(f"\nDone. Open: {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/dump_hdf5_images.py
+++ b/tools/dump_hdf5_images.py
@@ -31,7 +31,7 @@ from PIL import Image, ImageDraw
 # --- configuration ----------------------------------------------------------
 COLOURMAPS = ["gray", "viridis", "inferno", "magma", "turbo", "hot", "cividis"]
 DEFAULT_ANIM_CMAP = "viridis"
-UPSCALE = 8                # integer pixel zoom for crisp viewing
+UPSCALE = 8  # integer pixel zoom for crisp viewing
 GIF_FPS = 15
 INTERP = {"nearest": Image.NEAREST, "bilinear": Image.BILINEAR}
 
@@ -66,9 +66,7 @@ def montage(tiles, cols, pad=6, bg=(30, 30, 30)):
         return None
     tw, th = tiles[0].size
     rows = (len(tiles) + cols - 1) // cols
-    canvas = Image.new(
-        "RGB", (cols * tw + (cols + 1) * pad, rows * th + (rows + 1) * pad), bg
-    )
+    canvas = Image.new("RGB", (cols * tw + (cols + 1) * pad, rows * th + (rows + 1) * pad), bg)
     for i, tile in enumerate(tiles):
         r, c = divmod(i, cols)
         canvas.paste(tile, (pad + c * (tw + pad), pad + r * (th + pad)))
@@ -131,8 +129,10 @@ def dump_animated(frames, frame_idx, out_dir):
     # Montage: every Nth frame for a quick overview of the whole sequence.
     step = max(1, n // 24)
     overview = [
-        label(upscale(colourize(frames[i], DEFAULT_ANIM_CMAP, vmin, vmax), 4, Image.NEAREST),
-              f"f{int(frame_idx[i])}")
+        label(
+            upscale(colourize(frames[i], DEFAULT_ANIM_CMAP, vmin, vmax), 4, Image.NEAREST),
+            f"f{int(frame_idx[i])}",
+        )
         for i in range(0, n, step)
     ]
     montage(overview, cols=6).save(os.path.join(out_dir, "animated_overview.png"))
@@ -144,16 +144,26 @@ def dump_animated(frames, frame_idx, out_dir):
         for c in COLOURMAPS
     ]
     montage(tiles, cols=3).save(os.path.join(out_dir, "colourmaps_anim_peak.png"))
-    print(f"  wrote {n} frame PNGs + animated.gif + overview + peak compare (frame {int(frame_idx[peak])})")
+    print(
+        f"  wrote {n} frame PNGs + animated.gif + overview + peak compare (frame {int(frame_idx[peak])})"
+    )
 
 
 def main():
-    h5_path = sys.argv[1] if len(sys.argv) > 1 else os.path.join(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-        "kinora", "examples", "trajectory_export.h5",
+    h5_path = (
+        sys.argv[1]
+        if len(sys.argv) > 1
+        else os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "kinora",
+            "examples",
+            "trajectory_export.h5",
+        )
     )
-    out_dir = sys.argv[2] if len(sys.argv) > 2 else os.path.join(
-        tempfile.gettempdir(), "kinora_image_dump"
+    out_dir = (
+        sys.argv[2]
+        if len(sys.argv) > 2
+        else os.path.join(tempfile.gettempdir(), "kinora_image_dump")
     )
     os.makedirs(out_dir, exist_ok=True)
     print(f"file:   {h5_path}")


### PR DESCRIPTION
## Advanced Visualisations — background-image overlays

First stage of the new Advanced Visualisations work: render pre-computed bitmap data (e.g. density fields) from the loaded HDF5 file onto the ground plane as an overlay. This is opt-in, self-describing, and degrades cleanly when a file has no such data.

### What's new

**"Advanced Visualisations" panel** (sidebar) that only appears when the loaded file actually provides extra visualisation data:
- **Show Overlay** toggle
- **Source** dropdown listing every available background bitmap (one active at a time), built to accept future option types
- **Colour** scheme and **Interpolation** selectors

**Background image overlay** on `Kinora_Ground_Plane`:
- **Static** source (`image_data`) and **animated** source (`image_frame_data`), selectable
- Animated sources are preloaded and **swapped per frame by a frame-change handler kept in sync with the agent streaming** (same Blender→data frame mapping as `core.streaming`)
- **Colour schemes** (Viridis/Inferno/Magma/Turbo/Hot/Cividis/Grayscale) and **interpolation** (Linear/Closest/Cubic) update live with no file re-read
- Toggling the overlay on switches Solid/Wireframe viewports to **Material Preview** (so the emission material is actually visible); toggling off reverts to **Solid**. Rendered is left untouched.

### Design notes

- **Colour mapping is done in-shader** via a `ColorRamp` node fed by the raw value image; colour maps are **baked from matplotlib offline** into `core/colormaps.py` (matplotlib doesn't play well inside Blender). Value is interpolated first, then colourised.
- **Normalisation is the upstream data processing's responsibility**: image values are assumed pre-normalised to `[0, 1]` and simply clipped — the addon does no rescaling.
- The image is **UV-mapped to the walkable-area bounding box** (stored on the plane at creation) and clipped outside it, so the 10% padding ring keeps the plane's neutral grey. HDF5 images are top-down (row 0 = world y-max), so pixels are flipped into Blender's bottom-up buffer.
- The overlay never breaks loading/interaction: missing/malformed data, no plane, or a read error all fall back to the plain grey plane.

### Files
- `io/hdf5_reader.py` — detect optional background datasets into a manifest
- `core/overlay.py` — overlay build, animation, viewport-shading sync
- `core/colormaps.py` — baked colour-map LUTs + ColorRamp applicator
- `__init__.py` / `panels.py` / `operators.py` / `core/geometry.py` — properties, UI, load wiring, plane bounds
- `kinora/examples/trajectory_export.h5` — example file carrying the new datasets (consistent with the existing `.h5` example)
- `tools/dump_hdf5_images.py` — standalone dev utility to render every image/frame of a file to PNGs for inspection (not part of the addon)

### Verification
- `ruff check` and `ruff format --check` clean
- Headless Blender checks: data detection/manifest, panel visibility + dynamic dropdown, ColorRamp build + live colour/interpolation switch, animated frame mapping (step=1 and step>1, nearest-frame fallback, handler teardown), and callback wiring
- Static and animated overlays confirmed in the Blender viewport

> Note: HDF5 features need **Blender 5.x** (4.2's bundled numpy 1.24 breaks the deps' h5py). Colours are exact under the **Standard** view transform; the default AgX/Filmic will tone-map them.

### Next on this branch
Follow-up Advanced Visualisations improvements: agent colouration from `position_data`, colouring sections of agent trajectories, and Voronoi geometry cell overlays as independent objects (`polygon_data`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
